### PR TITLE
Make App fill entire viewport

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -5,8 +5,8 @@
     <meta name="color-scheme" content="light dark" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
-  <body>
-    <div id="root"></div>
+  <body style="height: 100vh">
+    <div id="root" style="height: 100%"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,13 +1,13 @@
-// import React from 'react';
 import { Routes, Route } from 'react-router-dom';
-import Stats from './pages/Stats';
+import { Box } from '@mui/material';
+import Stats from './pages/Stats/Stats';
 import Logs from './pages/Logs';
 import Settings from './pages/Settings';
 import NavBar from './components/NavBar/NavBar';
 
 export default function App() {
   return (
-    <>
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <NavBar />
       <Routes>
         <Route path="/" element={<Stats />} />
@@ -15,6 +15,6 @@ export default function App() {
         <Route path="/settings" element={<Settings />} />
         <Route path="*" element={<div>Page not found</div>} />
       </Routes>
-    </>
+    </Box>
   );
 }


### PR DESCRIPTION
The App component now fills the entire viewport of Docker Desktop (green outline).

A page component (red outline) will fill the remaining vertical space if it is given a `flexGrow: 1` style.

![Screenshot 2023-06-15 at 10 18 18 AM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/99a58868-9193-48b6-a630-0f31bfb8f5f9)
