### PR TITLE
View live data on the Stats page

### DIFF
--- a/ui/src/hooks/useStats.ts
+++ b/ui/src/hooks/useStats.ts
@@ -1,0 +1,94 @@
+import { createDockerDesktopClient } from '@docker/extension-api-client';
+import { useState, useEffect } from 'react';
+
+// Obtain docker destkop extension client
+const client = createDockerDesktopClient();
+
+const useDockerDesktopClient = () => {
+  return client;
+};
+
+export interface DockerStats {
+  BlockIO: string;
+  CPUPerc: string;
+  Container: string;
+  ID: string;
+  MemPerc: string;
+  MemUsage: string;
+  Name: string;
+  NetIO: string;
+  PIDs: string;
+}
+
+/**
+ * A custom hook which gets the stats of all Docker containers.
+ */
+export const useStats = () => {
+  const ddClient = useDockerDesktopClient();
+  const [response, setResponse] = useState<DockerStats[]>();
+
+  /**
+   * Execute the docker stats command to get the stats of the container(s).
+   * Docs: https://docs.docker.com/desktop/extensions-sdk/dev/api/docker/
+   *
+   * The exec() method will create a stream of data which, once per second,
+   * clears the terminal and logs the new stats. If you have three containers,
+   * the ouput will look like this:
+   *
+   * ---- (first elapsed second) ----
+   * stdout: ` [2J [H{"BlockIO":"0B / 2.15MB","CPUPerc":"1.00%","Container":"3135d5caf908", ... }`
+   * stdout: `{"BlockIO":"0B / 2.15MB","CPUPerc":"2.00%","Container":"083cd15faa7f", ... }`
+   * stdout: `{"BlockIO":"0B / 2.15MB","CPUPerc":"3.00%","Container":"1bc20b67e59b", ... }`
+   *
+   * ---- (second elapsed second) ----
+   * stdout: ` [2J [H{"BlockIO":"0B / 2.15MB","CPUPerc":"1.10%","Container":"3135d5caf908", ... }`
+   * stdout: `{"BlockIO":"0B / 2.15MB","CPUPerc":"2.20%","Container":"083cd15faa7f", ... }`
+   * stdout: `{"BlockIO":"0B / 2.15MB","CPUPerc":"3.30%","Container":"1bc20b67e59b", ... }`
+   *
+   * ... and so on.
+   *
+   * It is important to note that we need to remove the " [2J [H"  from the
+   * first stdout before it can be parsed as a JSON. To do this, we replace
+   * the TERMINAL_CLEAR_CODE (" [2J [H") with an empty string.
+   */
+  useEffect(() => {
+    let newData: DockerStats[] = [];
+
+    const TERMINAL_CLEAR_CODE = '\x1B[2J[H';
+
+    const result = ddClient.docker.cli.exec(
+      'stats',
+      ['--all', '--no-trunc', '--format', '{{ json . }}'],
+      {
+        stream: {
+          onOutput(data) {
+            if (data.stdout?.includes(TERMINAL_CLEAR_CODE)) {
+              // This stdout begins with the terminal clear code,
+              // meaning that it is a new sample of data.
+              setResponse(newData);
+              newData = [];
+              newData.push(JSON.parse(data.stdout.replace(TERMINAL_CLEAR_CODE, '')));
+            } else {
+              newData.push(JSON.parse(data.stdout ?? ''));
+            }
+          },
+          onError(error) {
+            console.error(error);
+          },
+          onClose(exitCode) {
+            console.log('docker stats exec exited with code ' + exitCode);
+          },
+          splitOutputLines: true,
+        },
+      }
+    );
+
+    // Clean-up function
+    return () => {
+      result.close();
+      newData = [];
+    };
+  }, [ddClient]);
+
+  return response;
+};

--- a/ui/src/pages/Stats/Stats.tsx
+++ b/ui/src/pages/Stats/Stats.tsx
@@ -14,55 +14,9 @@ import {
   Box,
   Stack,
   LinearProgress,
+  CircularProgress,
 } from '@mui/material';
-
-interface DockerStats {
-  Container?: string;
-  Name: string;
-  ID: string;
-  CPUPerc: string;
-  MemPerc: string;
-  MemUsage: string;
-  NetIO: string;
-  BlockIO: string;
-  PIDs: string;
-}
-
-const MOCK_STATS: Array<DockerStats> = [
-  {
-    BlockIO: '46.3MB / 24MB',
-    CPUPerc: '4.00%',
-    Container: '083cd15faa7f7853f60bde5712b8eb5c87828bbfaa6789ca62681c9632176b59',
-    ID: '083cd15faa7f7853f60bde5712b8eb5c87828bbfaa6789ca62681c9632176b59',
-    MemPerc: '5.03%',
-    MemUsage: '73.77MiB / 3.841GiB',
-    Name: 'loving_shannon',
-    NetIO: '232MB / 33.9MB',
-    PIDs: '25',
-  },
-  {
-    BlockIO: '0B / 2.15MB',
-    CPUPerc: '1.00%',
-    Container: '1bc20b67e59b65e8ef0007bdc7c6b61e77c3b236e55d47572f85f6cf12d44f51',
-    ID: '1bc20b67e59b65e8ef0007bdc7c6b61e77c3b236e55d47572f85f6cf12d44f51',
-    MemPerc: '22.5%',
-    MemUsage: '40.19MiB / 3.841GiB',
-    Name: 'service',
-    NetIO: '4.32MB / 25.2kB',
-    PIDs: '22',
-  },
-  {
-    BlockIO: '7.86MB / 1.76MB',
-    CPUPerc: '20.1%',
-    Container: 'e7b85b0e30b5e524649ae52f2633ca61291b411b18d97fb403d1aedd00f0b801',
-    ID: 'e7b85b0e30b5e524649ae52f2633ca61291b411b18d97fb403d1aedd00f0b801',
-    MemPerc: '31.1%',
-    MemUsage: '2.738MiB / 3.841GiB',
-    Name: 'docker-tutorial',
-    NetIO: '36.4kB / 618kB',
-    PIDs: '5',
-  },
-];
+import { useStats, DockerStats } from '../../hooks/useStats';
 
 const HEADERS: Array<string> = [
   '',
@@ -76,9 +30,9 @@ const HEADERS: Array<string> = [
 ];
 
 export default function Stats() {
-  const [stats, setStats] = useState<Array<DockerStats>>(MOCK_STATS);
+  const stats = useStats();
 
-  return (
+  return stats ? (
     <TableContainer component={Paper} sx={{ background: 'none', border: 'none' }}>
       <Table size="small" stickyHeader>
         <TableHead>
@@ -97,6 +51,10 @@ export default function Stats() {
         </TableBody>
       </Table>
     </TableContainer>
+  ) : (
+    <Box sx={{ p: 4, display: 'flex', justifyContent: 'center' }}>
+      <CircularProgress />
+    </Box>
   );
 }
 
@@ -145,7 +103,7 @@ function Row({ Name, ID, CPUPerc, MemUsage, MemPerc, NetIO, BlockIO, PIDs }: Doc
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={9}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={HEADERS.length}>
           <Collapse in={open} timeout="auto" unmountOnExit>
             {/*********** This Box is a placeholder for a Graph component ************/}
             <Box


### PR DESCRIPTION
## Overview
- create `useStats` hook which returns live stats for all containers
- modified `Stats` page to use this hook instead of mock data
- the live data initially takes a second or two to load, so we render a `CircularProgress` component in place of the table while the stats are the loading

### Loading
![Screenshot 2023-06-15 at 9 37 21 PM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/7c1b8ec5-c2ab-40b9-8bce-694f0a6c5b33)

### Live data
![Screenshot 2023-06-15 at 9 37 02 PM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/b0b8a9a0-6f47-4907-90a4-5d23dfbc6a17)




