### PR TITLE
Improve Makefile scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,7 @@ install-extension: build-extension ## Install the extension
 update-extension: build-extension ## Update the extension
 	docker extension update $(IMAGE):$(TAG)
 
-build-update-debug: # Build and update the extension, and put it into debug mode
-	docker build --tag=$(IMAGE):$(TAG) .
-	docker extension update $(IMAGE):$(TAG)
+update-debug-extension: update-extension # Update the extension and put it into debug mode
 	docker extension dev debug $(IMAGE):$(TAG)
 
 prepare-buildx: ## Create buildx builder for multi-arch build, if not exists

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ build-extension: ## Build service image to be deployed as a desktop extension
 	docker build --tag=$(IMAGE):$(TAG) .
 
 install-extension: build-extension ## Install the extension
-	docker extension install $(IMAGE):$(TAG)
+	docker extension install $(IMAGE):$(TAG) -f
 
 update-extension: build-extension ## Update the extension
-	docker extension update $(IMAGE):$(TAG)
+	docker extension update $(IMAGE):$(TAG) -f
 
 update-debug-extension: update-extension # Update the extension and put it into debug mode
 	docker extension dev debug $(IMAGE):$(TAG)


### PR DESCRIPTION
## Overview

1. Add the `-f` flag to the `install-extension` and `update-extension` script to automatically accept the warning.
2. Remove the redundancy in the `build-update-debug` script and rename to `update-debug-extension` match naming pattern of other scripts.