### PR TITLE
Feature added: Ability to filter logs via type

### DIFF
--- a/ui/src/actions/fetchAllContainerLogs.tsx
+++ b/ui/src/actions/fetchAllContainerLogs.tsx
@@ -22,7 +22,11 @@ const useDockerDesktopClient = () => {
 
 const ddClient = useDockerDesktopClient();
 
-export default async function fetchAllContainerLogs() {
+export default async function fetchAllContainerLogs(
+  stdout?: 'stdout',
+  stderr?: 'stderr',
+  off?: 'off'
+) {
   try {
     // Get an array of all (running and stopped) containers
     const allContainers = (await ddClient.docker.listContainers({
@@ -51,8 +55,16 @@ export default async function fetchAllContainerLogs() {
               container.Id
             );
 
-            // Resolve with the array of all logs
-            resolve([...stderrLogs, ...stdoutLogs]);
+            //Resolve with the array of all logs
+            if (stderr) {
+              resolve([...stderrLogs]);
+            } else if (stdout) {
+              resolve([...stdoutLogs]);
+            } else if (off) {
+              resolve([]);
+            } else {
+              resolve([...stderrLogs, ...stdoutLogs]);
+            }
           })
           .catch((err) => reject(err));
       });

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -19,11 +19,17 @@ import * as React from 'react';
 type SideBarProps = {
   drawerOpen: boolean;
   setDrawerOpen: Function;
+  type: boolean[];
+  setType: Function;
 };
 
-export default function SideBar({ drawerOpen, setDrawerOpen }: SideBarProps) {
+export default function SideBar({
+  drawerOpen,
+  setDrawerOpen,
+  type,
+  setType,
+}: SideBarProps) {
   const [container, setContainer] = React.useState([true, false]);
-  const [type, setType] = React.useState([true, false]);
   const [hoursAgo, setHoursAgo] = React.useState('');
   const [upUntil, setUpUntil] = React.useState('');
 
@@ -70,7 +76,11 @@ export default function SideBar({ drawerOpen, setDrawerOpen }: SideBarProps) {
   };
 
   return (
-    <Drawer anchor="right" open={drawerOpen} onClose={() => setDrawerOpen(false)}>
+    <Drawer
+      anchor="right"
+      open={drawerOpen}
+      onClose={() => setDrawerOpen(false)}
+    >
       <Box role="presentation" sx={{ width: '250px' }}>
         <Typography variant="h6">Filters</Typography>
         <Divider />
@@ -111,11 +121,15 @@ export default function SideBar({ drawerOpen, setDrawerOpen }: SideBarProps) {
           <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
             <FormControlLabel
               label="Container 1"
-              control={<Checkbox checked={container[0]} onChange={checkContainer1} />}
+              control={
+                <Checkbox checked={container[0]} onChange={checkContainer1} />
+              }
             />
             <FormControlLabel
               label="Container 2"
-              control={<Checkbox checked={container[1]} onChange={checkContainer2} />}
+              control={
+                <Checkbox checked={container[1]} onChange={checkContainer2} />
+              }
             />
           </Box>
         </List>

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react';
-import { Search, Clear, FilterList, KeyboardArrowUp, KeyboardArrowDown } from '@mui/icons-material';
+import {
+  Search,
+  Clear,
+  FilterList,
+  KeyboardArrowUp,
+  KeyboardArrowDown,
+} from '@mui/icons-material';
 import {
   Box,
   Stack,
@@ -19,14 +25,16 @@ import {
 } from '@mui/material';
 import ContainerIcon from '../../components/ContainerIcon/ContainerIcon';
 import SideBar from '../../components/Sidebar/Sidebar';
-import fetchAllContainerLogs, { DockerLog } from '../../actions/fetchAllContainerLogs';
+import fetchAllContainerLogs, {
+  DockerLog,
+} from '../../actions/fetchAllContainerLogs';
 
 const HEADERS = ['', 'Timestamp', 'Container', 'Message'];
 
 export default function Logs() {
   // Access the custom theme (provided by DockerMuiThemeProvider)
   const theme = useTheme();
-
+  const [type, setType] = useState([true, true]);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [logs, setLogs] = useState<DockerLog[]>([]);
   const [filteredLogs, setFilteredLogs] = useState<DockerLog[]>(logs);
@@ -39,9 +47,40 @@ export default function Logs() {
     });
   }, []);
 
+  useEffect(() => {
+    if (JSON.stringify(type) === JSON.stringify([true, false])) {
+      fetchAllContainerLogs('stdout').then((allLogs) => {
+        setLogs(allLogs);
+        setFilteredLogs(allLogs);
+        console.log('only stdout');
+      });
+    } else if (JSON.stringify(type) === JSON.stringify([false, true])) {
+      fetchAllContainerLogs(undefined, 'stderr').then((allLogs) => {
+        setLogs(allLogs);
+        setFilteredLogs(allLogs);
+        console.log('only stout');
+      });
+    } else if (JSON.stringify(type) === JSON.stringify([false, false])) {
+      fetchAllContainerLogs(undefined, undefined, 'off').then((allLogs) => {
+        setLogs(allLogs);
+        setFilteredLogs(allLogs);
+      });
+    } else {
+      fetchAllContainerLogs().then((allLogs) => {
+        setLogs(allLogs);
+        setFilteredLogs(allLogs);
+      });
+    }
+  }, type);
+
   return (
     <>
-      <SideBar drawerOpen={drawerOpen} setDrawerOpen={setDrawerOpen} />
+      <SideBar
+        drawerOpen={drawerOpen}
+        setDrawerOpen={setDrawerOpen}
+        type={type}
+        setType={setType}
+      />
       <Box sx={{ minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         <Stack direction="row" spacing={2}>
           <OutlinedInput
@@ -59,7 +98,10 @@ export default function Logs() {
                   fontSize="small"
                   // Use visibility instead of conditional rendering (`searchText && <InputAdornment>`)
                   // so that the width of the <OutlinedInput> does not change.
-                  sx={{ cursor: 'pointer', visibility: searchText ? 'visible' : 'hidden' }}
+                  sx={{
+                    cursor: 'pointer',
+                    visibility: searchText ? 'visible' : 'hidden',
+                  }}
                   onClick={() => setSearchText('')}
                 />
               </InputAdornment>
@@ -92,7 +134,9 @@ export default function Logs() {
               <TableRow>
                 {HEADERS.map((header) => (
                   <TableCell>
-                    <Typography sx={{ whiteSpace: 'nowrap', fontWeight: 'bold' }}>
+                    <Typography
+                      sx={{ whiteSpace: 'nowrap', fontWeight: 'bold' }}
+                    >
                       {header}
                     </Typography>
                   </TableCell>
@@ -116,9 +160,16 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
 
   return (
     <>
-      <TableRow hover sx={{ '& td': { border: 'none', paddingTop: 0, paddingBottom: 0 } }}>
+      <TableRow
+        hover
+        sx={{ '& td': { border: 'none', paddingTop: 0, paddingBottom: 0 } }}
+      >
         <TableCell sx={{ p: 0 }}>
-          <IconButton size="small" sx={{ background: 'none' }} onClick={() => setOpen(!open)}>
+          <IconButton
+            size="small"
+            sx={{ background: 'none' }}
+            onClick={() => setOpen(!open)}
+          >
             {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
           </IconButton>
         </TableCell>
@@ -126,7 +177,14 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
           <Typography sx={{ whiteSpace: 'nowrap' }}>{time}</Typography>
         </TableCell>
         <TableCell>
-          <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Box
+            sx={{
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+            }}
+          >
             {/* TODO: access the custom theme colors instead of hardcoding the color */}
             <ContainerIcon htmlColor="#228375" />
             <Typography>{containerName}</Typography>
@@ -155,7 +213,10 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
       </TableRow>
       <TableRow>
         <TableCell sx={{ p: 0 }} />
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={HEADERS.length - 1}>
+        <TableCell
+          style={{ paddingBottom: 0, paddingTop: 0 }}
+          colSpan={HEADERS.length - 1}
+        >
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Box
               sx={{


### PR DESCRIPTION
### Overview
**Code Changes**

- Added UseEffect to Logs.tsx for changing display of logs based off type state
- Added edge cases to fetchAllContainerLogs() for filtering functionality
- Moves state of type and setType from Sidebar.tsx to Logs.tsx

**User Experience**

- Ability to toggle all logs off or on
- Ability to display only stdout logs
- Ability to display only stderr logs

### Display
**Note: In pictures provided, nothing displays for stderr because I did not have any stderr logs to show at time of testing**
<img width="1529" alt="Screenshot 2023-06-21 at 4 00 41 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/110566167/2f28c1cc-9f3d-4375-aea3-f73bd01dcb8f">
<img width="1528" alt="Screenshot 2023-06-21 at 4 01 10 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/110566167/8438e43c-5580-4d78-b488-56333bda8866">
<img width="1527" alt="Screenshot 2023-06-21 at 4 01 34 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/110566167/6fdd35f8-7ac2-42a3-a4f8-cb68b2d7f8bb">

