### PR TITLE
Make Stats table rows collapsed by default

### DIFF
--- a/ui/src/pages/Stats/Stats.tsx
+++ b/ui/src/pages/Stats/Stats.tsx
@@ -59,7 +59,7 @@ export default function Stats() {
 }
 
 function Row({ Name, ID, CPUPerc, MemUsage, MemPerc, NetIO, BlockIO, PIDs }: DockerStats) {
-  const [open, setOpen] = useState<boolean>(true);
+  const [open, setOpen] = useState<boolean>(false);
 
   return (
     <>


### PR DESCRIPTION
Small change.

Reason: it is jarring for the user to see all the graphs appear at the same time.

Instead, the user should selectively expand rows.