### PR TITLE
UI improvements for Logs table

### DIFF
--- a/ui/src/actions/fetchAllContainerLogs.ts
+++ b/ui/src/actions/fetchAllContainerLogs.ts
@@ -12,18 +12,20 @@ export default async function fetchAllContainerLogs(
           .exec('logs', ['--timestamps', container.Id])
           .then((execResult) => {
             // Create an array of error logs
+            // Remove the leading forward slash on the container name
             const stderrLogs = parseLogsString(
               execResult.stderr,
               'stderr',
-              container.Names[0],
+              container.Names[0].replace(/^\//, ''),
               container.Id
             );
 
             // Create an array of standard logs
+            // Remove the leading forward slash on the container name
             const stdoutLogs = parseLogsString(
               execResult.stdout,
               'stdout',
-              container.Names[0],
+              container.Names[0].replace(/^\//, ''),
               container.Id
             );
 
@@ -34,7 +36,7 @@ export default async function fetchAllContainerLogs(
       });
     });
 
-    // Fulfill all the promises and flatten the result
+    // Fulfill all the promises
     const promiseResults = await Promise.allSettled(logsPromises);
 
     let allLogs: DockerLog[] = [];

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -145,7 +145,7 @@ export default function SideBar({
           <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
             {containers.map(({ Names, Id }) => (
               <FormControlLabel
-                label={Names}
+                label={Names[0].replace(/^\//, '')}
                 control={
                   <Checkbox
                     checked={filters.allowedContainers.has(Id)}

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -174,7 +174,7 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
             }}
           >
             {/* TODO: access the custom theme colors instead of hardcoding the color */}
-            <ContainerIcon htmlColor="#228375" height="18" width="18" />
+            <ContainerIcon htmlColor="#228375" />
             <Typography
               sx={{
                 whiteSpace: 'nowrap',

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -161,13 +161,30 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
           </IconButton>
         </TableCell>
         <TableCell>
-          <Typography sx={{ whiteSpace: 'nowrap' }}>{time}</Typography>
+          <Typography sx={{ whiteSpace: 'nowrap' }}>{time.split('.')[0]}</Typography>
         </TableCell>
         <TableCell>
-          <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Box
+            sx={{
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              maxWidth: '150px',
+            }}
+          >
             {/* TODO: access the custom theme colors instead of hardcoding the color */}
-            <ContainerIcon htmlColor="#228375" />
-            <Typography>{containerName}</Typography>
+            <ContainerIcon htmlColor="#228375" height="18" width="18" />
+            <Typography
+              sx={{
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+                fontFamily: 'monospace',
+              }}
+            >
+              {containerName}
+            </Typography>
           </Box>
         </TableCell>
         <TableCell


### PR DESCRIPTION
## Overview

Some UI improvements for the logs table.
- Cut off the timestamp at the seconds mark (milliseconds and microseconds is too granular)
- Add a maximum width to the container column so that a long container name is truncated. This gives more room for the message.
- Remove the forward slash from the container name in both the table and the sidebar.

![Screenshot 2023-06-23 at 8 07 02 PM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/06e10521-efc3-4c70-9f26-ae66a05789c6)
