### PR TITLE
Add ! icon to stderr process logs, decrease size of container icon

### DIFF
--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -26,7 +26,7 @@ import {
   useTheme,
 } from '@mui/material';
 import ContainerIcon from '../../components/ContainerIcon/ContainerIcon';
-import PriorityHighRoundedIcon from '@mui/icons-material/PriorityHighRounded';
+import ErrorRoundedIcon from '@mui/icons-material/ErrorRounded';
 import SideBar from '../../components/Sidebar/Sidebar';
 import fetchAllContainers from '../../actions/fetchAllContainers';
 import fetchAllContainerLogs from '../../actions/fetchAllContainerLogs';
@@ -164,6 +164,12 @@ export default function Logs() {
 
 function Row({ containerName, containerId, time, stream, log }: DockerLog) {
   const [open, setOpen] = useState<boolean>(false);
+  const logsDisplayStyle = {
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    fontFamily: 'monospace',
+  };
 
   return (
     <>
@@ -204,36 +210,26 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
           sx={{
             // The combination of width: 100% and maxWidth: 0 makes the cell grow to fit
             // the horizontal space. The table will not overflow in the x direction.
+
             width: '100%',
             maxWidth: 0,
           }}
         >
-          {stream === 'stdout' ? (
-            <Typography
-              sx={{
-                // Logs will be cut off with an ellipsis instead of wrapping or overflowing.
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-                overflow: 'hidden',
-                fontFamily: 'monospace',
-              }}
-            >
-              {log}
-            </Typography>
-          ) : (
-            <Typography
-              sx={{
-                // Logs will be cut off with an ellipsis instead of wrapping or overflowing.
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-                overflow: 'hidden',
-                fontFamily: 'monospace',
-              }}
-            >
-              <PriorityHighRoundedIcon htmlColor="red" sx={{ fontSize: 14 }} />
-              {log}
-            </Typography>
-          )}
+          <Typography
+            sx={
+              // Logs will be cut off with an ellipsis instead of wrapping or overflowing.
+              logsDisplayStyle
+            }
+          >
+            {stream === 'stdout' ? (
+              log
+            ) : (
+              <>
+                <ErrorRoundedIcon htmlColor="red" sx={{ fontSize: 14 }} />
+                {log}
+              </>
+            )}
+          </Typography>
         </TableCell>
       </TableRow>
       <TableRow>

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -26,6 +26,7 @@ import {
   useTheme,
 } from '@mui/material';
 import ContainerIcon from '../../components/ContainerIcon/ContainerIcon';
+import PriorityHighRoundedIcon from '@mui/icons-material/PriorityHighRounded';
 import SideBar from '../../components/Sidebar/Sidebar';
 import fetchAllContainers from '../../actions/fetchAllContainers';
 import fetchAllContainerLogs from '../../actions/fetchAllContainerLogs';
@@ -207,17 +208,32 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
             maxWidth: 0,
           }}
         >
-          <Typography
-            sx={{
-              // Logs will be cut off with an ellipsis instead of wrapping or overflowing.
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
-              overflow: 'hidden',
-              fontFamily: 'monospace',
-            }}
-          >
-            {log}
-          </Typography>
+          {stream === 'stdout' ? (
+            <Typography
+              sx={{
+                // Logs will be cut off with an ellipsis instead of wrapping or overflowing.
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+                fontFamily: 'monospace',
+              }}
+            >
+              {log}
+            </Typography>
+          ) : (
+            <Typography
+              sx={{
+                // Logs will be cut off with an ellipsis instead of wrapping or overflowing.
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+                fontFamily: 'monospace',
+              }}
+            >
+              <PriorityHighRoundedIcon htmlColor="red" sx={{ fontSize: 14 }} />
+              {log}
+            </Typography>
+          )}
         </TableCell>
       </TableRow>
       <TableRow>

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -193,7 +193,7 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
             }}
           >
             {/* TODO: access the custom theme colors instead of hardcoding the color */}
-            <ContainerIcon htmlColor="#228375" />
+            <ContainerIcon htmlColor="#228375" sx={{ fontSize: 14 }} />
             <Typography
               sx={{
                 whiteSpace: 'nowrap',

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -7,6 +7,7 @@ import {
   KeyboardArrowUp,
   KeyboardArrowDown,
   Refresh,
+  ErrorRounded,
 } from '@mui/icons-material';
 import {
   Box,
@@ -26,7 +27,6 @@ import {
   useTheme,
 } from '@mui/material';
 import ContainerIcon from '../../components/ContainerIcon/ContainerIcon';
-import ErrorRoundedIcon from '@mui/icons-material/ErrorRounded';
 import SideBar from '../../components/Sidebar/Sidebar';
 import fetchAllContainers from '../../actions/fetchAllContainers';
 import fetchAllContainerLogs from '../../actions/fetchAllContainerLogs';
@@ -161,15 +161,14 @@ export default function Logs() {
     </>
   );
 }
-
+const logsDisplayStyle = {
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  fontFamily: 'monospace',
+};
 function Row({ containerName, containerId, time, stream, log }: DockerLog) {
   const [open, setOpen] = useState<boolean>(false);
-  const logsDisplayStyle = {
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-    fontFamily: 'monospace',
-  };
 
   return (
     <>
@@ -210,22 +209,19 @@ function Row({ containerName, containerId, time, stream, log }: DockerLog) {
           sx={{
             // The combination of width: 100% and maxWidth: 0 makes the cell grow to fit
             // the horizontal space. The table will not overflow in the x direction.
-
             width: '100%',
             maxWidth: 0,
           }}
         >
-          <Typography
-            sx={
-              // Logs will be cut off with an ellipsis instead of wrapping or overflowing.
-              logsDisplayStyle
-            }
-          >
+          <Typography sx={logsDisplayStyle}>
             {stream === 'stdout' ? (
               log
             ) : (
               <>
-                <ErrorRoundedIcon htmlColor="red" sx={{ fontSize: 14 }} />
+                <ErrorRounded
+                  htmlColor="red"
+                  sx={{ verticalAlign: 'middle', fontSize: 14, marginRight: 1 }}
+                />
                 {log}
               </>
             )}


### PR DESCRIPTION
### Overview

- Red ! icon present next to all stderr logs
- Container icon size decreased
- Typography code for logs made more DRY
 
### Before
<img width="1317" alt="Screenshot 2023-06-24 at 12 02 18 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/110566167/d55a59a3-23f9-4696-a173-d77d0f316a21">

### After
<img width="1078" alt="Screenshot 2023-06-25 at 7 09 36 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/110566167/c45c3963-1055-44d7-bd27-1957e3709d45">


