### PR TITLE
fix extension container display name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@
 services:
   myExtension:
     image: ${DESKTOP_PLUGIN_IMAGE}
+    container_name: dockerpulse
     volumes:
       - /var/run/docker.sock.raw:/var/run/docker.sock
       # Create a named volume which is mapped to the /grafana folder in the extension container


### PR DESCRIPTION
## Overview

- Add 'container_name' key to extension image in docker compose yaml file.
  - Previously, our extensions container name would automatically be assigned to a default name (service or myExtension1)
  - Now it will properly display "dockerpulse" as the name of the running container


![image](https://github.com/oslabs-beta/DockerPulse/assets/39440819/5912d144-d01a-4c1d-81dd-8411cb9d0daf)
