### PR TITLE
Resolve ESLint modules error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,10 @@
     "func-names": "off",
     "no-process-exit": "off",
     "object-shorthand": "off",
-    "class-methods-use-this": "off"
+    "class-methods-use-this": "off",
+    "node/no-unsupported-features/es-syntax": ["error", { "ignores": ["modules"] }]
+  },
+  "parserOptions": {
+    "sourceType": "module"
   }
 }


### PR DESCRIPTION
## Overview

Added to ESLint configuration file (.eslintrc):

```json
"rules": {
  ...
   "node/no-unsupported-features/es-syntax": ["error", { "ignores": ["modules"] }]
},
"parserOptions": {
    "sourceType": "module"
  }
```

Adding the parserOptions setting fixes this error:
![Screenshot 2023-06-26 at 11 39 12 AM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/09c81022-a27f-4036-8495-276252bd6ee2)

Adding the new rule ignores this error:
![Screenshot 2023-06-26 at 11 39 58 AM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/9b020104-c704-4f2d-89b2-a3cbfa36b945)

After both are added - no more error:
![Screenshot 2023-06-26 at 11 41 29 AM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/599a8bc8-1c5d-4afb-ad4f-915cde00a55d)

