### PR TITLE
Add time filter functionality

### DIFF
--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -20,6 +20,8 @@ type SideBarProps = {
   setFilters: React.Dispatch<React.SetStateAction<LogFilters>>;
   drawerOpen: boolean;
   setDrawerOpen: Function;
+  setValidFromTimestamp: Function;
+  setValidUntilTimestamp: Function;
 };
 
 export default function SideBar({
@@ -28,7 +30,10 @@ export default function SideBar({
   setFilters,
   drawerOpen,
   setDrawerOpen,
+  setValidFromTimestamp,
+  setValidUntilTimestamp,
 }: SideBarProps) {
+  // These represent user input of time regardless of validity
   const [fromTimestamp, setFromTimestamp] = useState('');
   const [untilTimestamp, setUntilTimestamp] = useState('');
 
@@ -51,6 +56,22 @@ export default function SideBar({
       ...filters,
       allowedContainers: newAllowedContainers,
     });
+  };
+
+  const checkFromValidity = (value: string) => {
+    if (!Number.isNaN(Date.parse(value))) {
+      setValidFromTimestamp(value);
+    } else {
+      setValidFromTimestamp('');
+    }
+  };
+
+  const checkUntilValidity = (value: string) => {
+    if (!Number.isNaN(Date.parse(value))) {
+      setValidUntilTimestamp(value);
+    } else {
+      setValidUntilTimestamp('');
+    }
   };
 
   return (
@@ -181,7 +202,10 @@ export default function SideBar({
               variant="outlined"
               size="small"
               value={fromTimestamp}
-              onChange={(e) => setFromTimestamp(e.target.value)}
+              onChange={(e) => {
+                setFromTimestamp(e.target.value);
+                checkFromValidity(e.target.value);
+              }}
               error={Number.isNaN(Date.parse(fromTimestamp || '0'))}
             />
             <TextField
@@ -189,7 +213,10 @@ export default function SideBar({
               variant="outlined"
               size="small"
               value={untilTimestamp}
-              onChange={(e) => setUntilTimestamp(e.target.value)}
+              onChange={(e) => {
+                setUntilTimestamp(e.target.value);
+                checkUntilValidity(e.target.value);
+              }}
               error={Number.isNaN(Date.parse(untilTimestamp || '0'))}
             />
           </Stack>

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -57,8 +57,6 @@ export default function Logs() {
     stdout: true,
     stderr: true,
     allowedContainers: new Set(),
-    fromTime: '',
-    untilTime: '',
   });
 
   useEffect(() => {

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -27,7 +27,7 @@ import {
   useTheme,
 } from '@mui/material';
 import ContainerIcon from '../../components/ContainerIcon/ContainerIcon';
-import SideBar from '../../components/SideBar/SideBar';
+import SideBar from '../../components/Sidebar/Sidebar';
 import fetchAllContainers from '../../actions/fetchAllContainers';
 import fetchAllContainerLogs from '../../actions/fetchAllContainerLogs';
 import { DockerLog, DockerContainer, LogFilters } from '../../types';
@@ -50,11 +50,15 @@ export default function Logs() {
   const [containers, setContainers] = useState<DockerContainer[]>([]);
   const [logs, setLogs] = useState<DockerLog[]>([]);
   const [searchText, setSearchText] = useState('');
+  const [validFromTimestamp, setValidFromTimestamp] = useState('');
+  const [validUntilTimestamp, setValidUntilTimestamp] = useState('');
 
   const [filters, setFilters] = useState<LogFilters>({
     stdout: true,
     stderr: true,
     allowedContainers: new Set(),
+    fromTime: '',
+    untilTime: '',
   });
 
   useEffect(() => {
@@ -79,6 +83,11 @@ export default function Logs() {
     if (!filters.stdout && stream === 'stdout') return false; // Filter out stdout
     if (!filters.stderr && stream === 'stderr') return false; // Filter out stderr
     if (!filters.allowedContainers.has(containerId)) return false; // Filter out containers
+    const convertTime = time.slice(0, time.indexOf('.') + 4);
+    const numTime = Date.parse(convertTime);
+    const numFromTime = Date.parse(validFromTimestamp);
+    const numUntilTime = Date.parse(validUntilTimestamp);
+    if (numTime > numUntilTime || numTime < numFromTime) return false;
     return true;
   });
 
@@ -90,6 +99,8 @@ export default function Logs() {
         containers={containers}
         filters={filters}
         setFilters={setFilters}
+        setValidFromTimestamp={setValidFromTimestamp}
+        setValidUntilTimestamp={setValidUntilTimestamp}
       />
       <Box sx={{ minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         <Stack direction="row" spacing={2}>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,7 +1,6 @@
 import { DockerDesktopClient } from '@docker/extension-api-client-types/dist/v1';
 
-export type DDClient = DockerDesktopClient
-
+export type DDClient = DockerDesktopClient;
 
 export type DockerLog = {
   containerName: string;
@@ -21,5 +20,6 @@ export type LogFilters = {
   stdout: boolean;
   stderr: boolean;
   allowedContainers: Set<string>;
-}
-
+  fromTime: string;
+  untilTime: string;
+};

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -20,6 +20,4 @@ export type LogFilters = {
   stdout: boolean;
   stderr: boolean;
   allowedContainers: Set<string>;
-  fromTime: string;
-  untilTime: string;
 };


### PR DESCRIPTION
### Overview

- User's input in 'From' and 'Until' are compared to times on process logs
- Process logs containing times within 'From' and 'Until' time range are displayed
- Process logs containing times out of time range are not displayed
- Failure to input anything, or deletion of inputs resets state,  and displays all process logs

**All process logs are within time range**
![Screenshot 2023-06-26 at 7 47 15 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/ab1f0d72-914a-4c11-8b88-be987c0f482f)

**Process logs are no longer within time range**
![Screenshot 2023-06-26 at 7 49 21 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/f7707d3d-5f43-4f2e-91b7-8df4810281cd)

**Deletion of input or no input at all renders all process logs**
![Screenshot 2023-06-26 at 7 52 01 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/64f7418c-85ac-4702-a799-a67f816fcdca)
