### PR TITLE
Add container color coding for filter drawer

### DIFF
--- a/ui/src/components/FilterDrawer/FilterDrawer.tsx
+++ b/ui/src/components/FilterDrawer/FilterDrawer.tsx
@@ -33,6 +33,7 @@ export default function FilterDrawer({
   setDrawerOpen,
   setValidFromTimestamp,
   setValidUntilTimestamp,
+  containerLabelColor,
 }: FilterDrawerProps) {
   // These represent user input of time regardless of validity
   const [fromTimestamp, setFromTimestamp] = useState('');
@@ -153,6 +154,9 @@ export default function FilterDrawer({
                       textOverflow: 'ellipsis',
                       overflow: 'hidden',
                       fontFamily: 'monospace',
+                      backgroundColor: containerLabelColor[Id],
+                      borderRadius: '5px',
+                      padding: 0.5,
                     }}
                   >
                     {Names[0].replace(/^\//, '')}


### PR DESCRIPTION
### Overview:

- Containers in filter drawer have matching colored backgrounds with respective containers on logs page

<img width="1355" alt="Screenshot 2023-06-29 at 3 23 25 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/110566167/84a79e57-bdb0-4215-9dae-ee995e715508">
