### PR TITLE
Styles / options: Grafana panels

### DIFF
--- a/backend/src/actions/grafana/createGrafanaPanelObject.ts
+++ b/backend/src/actions/grafana/createGrafanaPanelObject.ts
@@ -22,7 +22,7 @@ export default function createGrafanaPanelObject(
       break;
     }
     case 2: {
-      metricsName = 'RAM %';
+      metricsName = 'MEM %';
       break;
     }
     default: {
@@ -53,11 +53,11 @@ export default function createGrafanaPanelObject(
       custom: {
         axisCenteredZero: false,
         axisColorMode: 'text',
-        axisLabel: '',
+        axisLabel: metricsName,
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10, // Fill area under line
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -94,17 +94,18 @@ export default function createGrafanaPanelObject(
           },
         ],
       },
+      min: 0,
     },
     overrides: [
       {
         matcher: {
           id: 'byName',
-          options: 'Value',
+          options: 'Time',
         },
         properties: [
           {
-            id: 'displayName',
-            value: `${metricsName}`,
+            id: 'custom.fillBelowTo',
+            value: 'Value',
           },
         ],
       },
@@ -117,7 +118,7 @@ export default function createGrafanaPanelObject(
       calcs: [],
       displayMode: 'list',
       placement: 'bottom',
-      showLegend: true,
+      showLegend: false, // Do not show legend
     },
     tooltip: {
       mode: 'single',
@@ -138,7 +139,7 @@ export default function createGrafanaPanelObject(
     options: optionsObject,
     id: panelId,
     targets: targets,
-    title: `${containerName} ${metricsName}`,
+    title: '', // No title on panel to conserve vertical space
     type: 'timeseries',
     interval: '10s',
   };

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -73,19 +73,19 @@ export type GrafanaPanelFieldConfigKey = {
         value: number | null;
       }[];
     };
+    min?: number;
+    max?: number;
   };
   overrides: [
     {
       matcher: {
         id: string;
         options: string;
-      },
-      properties: [
-        {
-          id: string;
-          value: string;
-        }
-      ]
+      };
+      properties: {
+        id: string;
+        value: string;
+      }[];
     }
   ];
 };
@@ -138,4 +138,4 @@ export type DockerContainer = {
 export type QueryStringPanelID = {
   panelID: number;
   queryString: string;
-}
+};

--- a/ui/src/components/StatsGraph/StatsGraph.tsx
+++ b/ui/src/components/StatsGraph/StatsGraph.tsx
@@ -1,26 +1,30 @@
+import { Stack } from '@mui/material';
+
 type StatsGraphProps = {
   containerName: string;
   containerID: string;
 };
+
 export default function StatsGraph({ containerName, containerID }: StatsGraphProps) {
+  // The short-form containerID (12 digits) is used for the Grafana dashboards
+  // because the full container (64 digits) is too long. Grafana API sets a
+  // 40 character limit on a dashboard name.
+  const shortContainerID = containerID.slice(0, 12);
+
   return (
-    <>
+    <Stack direction="column" spacing={1}>
       <iframe
-        src={`http://localhost:2999/d-solo/${containerID.slice(
-          0,
-          12
-        )}/${containerName}?orgId=1&refresh=15s&panelId=1&from=now-15m&to=now`}
+        src={`http://localhost:2999/d-solo/${shortContainerID}/${containerName}?orgId=1&refresh=15s&panelId=1&from=now-15m&to=now`}
         width="100%"
-        height="200"
+        height="200px"
+        style={{ border: 0 }}
       />
       <iframe
-        src={`http://localhost:2999/d-solo/${containerID.slice(
-          0,
-          12
-        )}/${containerName}?orgId=1&refresh=15s&panelId=2&from=now-15m&to=now`}
+        src={`http://localhost:2999/d-solo/${shortContainerID}/${containerName}?orgId=1&refresh=15s&panelId=2&from=now-15m&to=now`}
         width="100%"
-        height="200"
+        height="200px"
+        style={{ border: 0 }}
       />
-    </>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Overview
- Put the Grafana iframes in a MUI Stack component
- Remove border of iframe
- Change a few things on the Grafana panel:
  - Y axis min set to 0
  - Filled graph
  - Remove title and legend to conserve vertical space
  - Add Y-axis label

![Screenshot 2023-06-30 at 9 49 39 AM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/8924da75-c5ab-4d63-b4aa-8b34fe552292)
