### PR TITLE
Bugfix: DDClient type

### DIFF
--- a/ui/src/components/AlertDialog/AlertDialog.tsx
+++ b/ui/src/components/AlertDialog/AlertDialog.tsx
@@ -16,10 +16,10 @@ import {
   InputAdornment,
 } from '@mui/material';
 import fetchAllContainers from '../../actions/fetchAllContainers';
-import { DockerDesktopClient, DockerContainer, Alert } from '../../types';
+import { DDClient, DockerContainer, Alert } from '../../types';
 
 type AlertDialogProps = {
-  ddClient: DockerDesktopClient;
+  ddClient: DDClient;
   dialogOpen: boolean;
   setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };


### PR DESCRIPTION
Previously was importing `DockerDesktopClient` when it should be `DDClient`. This was causing an import error. Thanks @leejun07 for the quick catch on this breaking bug.