### PR TITLE
Backend modularity and Docker Events Listener

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,13 +1,10 @@
 import fs from 'fs';
-import axios from 'axios';
 import extensionServer from './src/extensionServer';
 import metricsServer from './src/metricsServer';
-import createGrafanaDashboardObject from './src/actions/grafana/createGrafanaDashboardObject';
 import getGrafanaDatasource from './src/actions/grafana/getGrafanaDatasource';
-import startContainerMetricsStream from './src/actions/docker/startContainerMetricsStream';
 import startContainerEventListener from './src/actions/docker/startContainerEventListener';
-import { DockerContainer } from './src/types';
-import { DOCKER_DAEMON_SOCKET_PATH, SOCKETFILE, METRICS_PORT } from './src/constants';
+import onLoadSetup from './src/actions/docker/onLoadSetup';
+import { SOCKETFILE, METRICS_PORT } from './src/constants';
 
 // After a server is done with the unix domain socket, it is not automatically destroyed.
 // You must instead unlink the socket in order to reuse that address/path.
@@ -40,6 +37,7 @@ metricsServer.listen(METRICS_PORT, () => {
     const datasource = await getGrafanaDatasource();
 
     // Start data collection and create Grafana graphs for all containers available on load.
+    onLoadSetup(datasource);
 
     // Start container event listener
     startContainerEventListener(datasource);

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -5,6 +5,7 @@ import metricsServer from './src/metricsServer';
 import createGrafanaDashboardObject from './src/actions/grafana/createGrafanaDashboardObject';
 import getGrafanaDatasource from './src/actions/grafana/getGrafanaDatasource';
 import startContainerMetricsStream from './src/actions/docker/startContainerMetricsStream';
+import startContainerEventListener from './src/actions/docker/startContainerEventListener';
 import { DockerContainer } from './src/types';
 import { DOCKER_DAEMON_SOCKET_PATH, SOCKETFILE, METRICS_PORT } from './src/constants';
 
@@ -34,106 +35,14 @@ metricsServer.listen(METRICS_PORT, () => {
     console.log('⏳ Waiting ... ');
     await new Promise((r) => setTimeout(r, 1000 * 10));
     console.log('⌛ Done waiting.');
-
-    // Get a list of all the Docker containers
-    const response = await axios.get('/containers/json', {
-      socketPath: DOCKER_DAEMON_SOCKET_PATH,
-      params: { all: true },
-    });
-
-    // Populate two arrays, mapping through them in order ensures that their INDEX VALUES
-    // can properly CORRELATE each container's respective IDs and Names.
-
-    const containerIDs: string[] = [];
-    const containerNames: string[] = [];
-    (response.data as DockerContainer[]).forEach((el) => {
-      containerIDs.push(el.Id);
-      containerNames.push(el.Names[0].replace(/^\//, ''));
-    });
-
+    
     // Get necessary datasource information from Grafana directly.
     const datasource = await getGrafanaDatasource();
 
-    // Iterate through ID array and create a dashboard object for each container.
-    containerIDs.forEach(async (id, index) => {
-      const dashboard = createGrafanaDashboardObject(id, containerNames[index], datasource);
+    // Start data collection and create Grafana graphs for all containers available on load.
 
-      // Post request to Grafana API to create a dashboard using the returned dashboard object.
-      await axios.post(
-        'http://host.docker.internal:2999/api/dashboards/db',
-        JSON.stringify(dashboard),
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-
-      // A simple console log to show when graphs are done being posted to Grafana.
-      console.log(`📊 Grafana graphs 📊 for the ${containerNames[index]} container are ready!!`);
-    });
-
-    // Open up a streaming connection that listens for container 'start' and 'destroy events.
-    // Whenever a container starts we will create a dashboard with grafana graphs for that container.
-    // Whenever a container is destroyed, we will delete the corresponding grafana dashboard. (WIP)
-    const eventsRequest = await axios.get('/events', {
-      socketPath: DOCKER_DAEMON_SOCKET_PATH,
-      params: {
-        type: 'container',
-        filters: JSON.stringify({
-          event: ['start', 'destroy'],
-        }),
-      },
-      responseType: 'stream',
-    });
-
-    const eventStream = eventsRequest.data;
-    eventStream.on('data', async (eventData: Buffer) => {
-      const event = JSON.parse(eventData.toString());
-      console.log(`------------------------NEW EVENT------------------------`);
-      // console.log(event); // to view event object for debugging
-
-      // These will check for two actions, start and stop
-
-      // Start action: create new grafana graphs using name and id
-      if (event.Action === 'start') {
-        // Log
-        console.log('🚩 STARTED CONTAINER: ', event.Actor.Attributes.name, '!!');
-        const dashboard = createGrafanaDashboardObject(
-          event.Actor.ID,
-          event.Actor.Attributes.name,
-          datasource
-        );
-
-        await axios.post(
-          'http://host.docker.internal:2999/api/dashboards/db',
-          JSON.stringify(dashboard),
-          {
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }
-        );
-      }
-
-      // Destroy action: delete grafana DASHBOARD with the same name
-      // May need to consider swapping ID and container name in grafana dashboard
-      // to account for containers with the same name but different IDs
-      if (event.Action === 'destroy') {
-        console.log('💣 DESTROYED CONTAINER: ', event.Actor.Attributes.name, '!!');
-      }
-    });
-
-    eventStream.on('end', () => {
-      console.log('event request ended');
-    });
-
-    // For each container, create an HTTP request to the Docker Engine to get the stats.
-    // This is a streaming connection that will close when the container is deleted.
-    containerIDs.forEach(async (id) => {
-      // invoke function to open metrics stream
-      startContainerMetricsStream(id);
-    });
+    // Start container event listener
+    startContainerEventListener(datasource);
   } catch (err) {
     console.error(err);
   }

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -32,6 +32,10 @@ metricsServer.listen(METRICS_PORT, () => {
     console.log('⏳ Waiting ... ');
     await new Promise((r) => setTimeout(r, 1000 * 10));
     console.log('⌛ Done waiting.');
+    // STRETCH GOAL: Not a very likely scenario but consider this scenario:
+    // A CPU or MEM spike causes DockerPulse container to stop/restart
+    // but Grafana stays running, we may end up creating double the amount
+    // of containers. May need to delete all dashboards first.
 
     // Get necessary datasource information from Grafana directly.
     const datasource = await getGrafanaDatasource();

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -32,7 +32,7 @@ metricsServer.listen(METRICS_PORT, () => {
     console.log('⏳ Waiting ... ');
     await new Promise((r) => setTimeout(r, 1000 * 10));
     console.log('⌛ Done waiting.');
-    
+
     // Get necessary datasource information from Grafana directly.
     const datasource = await getGrafanaDatasource();
 

--- a/backend/src/actions/docker/onLoadSetup.ts
+++ b/backend/src/actions/docker/onLoadSetup.ts
@@ -23,8 +23,5 @@ export default async function onLoadSetup(datasource: GrafanaDatasource) {
   containerIDs.forEach(async (id, index) => {
     // Invoke function to start metrics stream and create Grafana Dashboard
     startStreamAndCreateDashboard(id, containerNames[index], datasource);
-
-    // A simple console log to show when graphs are done being posted to Grafana.
-    console.log(`📊 Grafana graphs 📊 for the ${containerNames[index]} container are ready!!`);
   });
 }

--- a/backend/src/actions/docker/onLoadSetup.ts
+++ b/backend/src/actions/docker/onLoadSetup.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import createGrafanaDashboardObject from "../grafana/createGrafanaDashboardObject";
+import startContainerMetricsStream from "./startContainerMetricsStream";
+import { DOCKER_DAEMON_SOCKET_PATH } from "../../constants";
+import { DockerContainer } from "../../types";
+
+export default async function onLoadSetup(datasource) {
+  // Get a list of all the Docker containers
+  const response = await axios.get('/containers/json', {
+    socketPath: DOCKER_DAEMON_SOCKET_PATH,
+    params: { all: true },
+  });
+
+  // Populate two arrays, mapping through them in order ensures that their INDEX VALUES
+  // can properly CORRELATE each container's respective IDs and Names.
+
+  const containerIDs: string[] = [];
+  const containerNames: string[] = [];
+  (response.data as DockerContainer[]).forEach((el) => {
+    containerIDs.push(el.Id);
+    containerNames.push(el.Names[0].replace(/^\//, ''));
+  });
+
+  // Iterate through ID array and create a dashboard object for each container.
+  containerIDs.forEach(async (id, index) => {
+    startContainerMetricsStream(id);
+    const dashboard = createGrafanaDashboardObject(id, containerNames[index], datasource);
+
+    // Post request to Grafana API to create a dashboard using the returned dashboard object.
+    await axios.post(
+      'http://host.docker.internal:2999/api/dashboards/db',
+      JSON.stringify(dashboard),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    // A simple console log to show when graphs are done being posted to Grafana.
+    console.log(`📊 Grafana graphs 📊 for the ${containerNames[index]} container are ready!!`);
+  });
+
+  
+
+}

--- a/backend/src/actions/docker/startContainerEventListener.ts
+++ b/backend/src/actions/docker/startContainerEventListener.ts
@@ -1,0 +1,68 @@
+import axios from "axios";
+import createGrafanaDashboardObject from "../grafana/createGrafanaDashboardObject";
+import startContainerMetricsStream from "./startContainerMetricsStream";
+import { DOCKER_DAEMON_SOCKET_PATH } from "../../constants";
+import { GrafanaDatasource } from "../../types";
+
+// Open up a streaming connection that listens for container 'start' and 'destroy events.
+// Whenever a container starts we will create a dashboard with grafana graphs for that container.
+// Whenever a container is destroyed, we will delete the corresponding grafana dashboard. (WIP)
+export default async function startContainerEventListener(datasource: GrafanaDatasource) {
+  const eventsRequest = await axios.get('/events', {
+    socketPath: DOCKER_DAEMON_SOCKET_PATH,
+    params: {
+      type: 'container',
+      filters: JSON.stringify({
+        event: ['start', 'destroy'],
+      }),
+    },
+    responseType: 'stream',
+  });
+  
+  const eventStream = eventsRequest.data;
+  eventStream.on('data', async (eventData: Buffer) => {
+    // Parse event data
+    const event = JSON.parse(eventData.toString());
+ 
+    // These will check for two actions, start and destroy.
+    // Start action: create new grafana graphs using name and id.
+    if (event.Action === 'start') {
+      // Display event start in console.
+      console.log('🚩 STARTED CONTAINER: ', event.Actor.Attributes.name, '!!');
+
+      // Open up a metrics stream for data collection.
+      startContainerMetricsStream(event.Actor.ID);
+
+      // Create a Grafana dashboard for the new container.
+      const dashboard = createGrafanaDashboardObject(
+        event.Actor.ID,
+        event.Actor.Attributes.name,
+        datasource
+      );
+  
+      // Post request to Grafana API that creates the dashboard using our dashboard object.
+      await axios.post(
+        'http://host.docker.internal:2999/api/dashboards/db',
+        JSON.stringify(dashboard),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    
+    }
+  
+    // Destroy action: delete grafana DASHBOARD with the same name
+    // May need to consider swapping ID and container name in grafana dashboard
+    // to account for containers with the same name but different IDs
+    if (event.Action === 'destroy') {
+      console.log('💣 DESTROYED CONTAINER: ', event.Actor.Attributes.name, '!!');
+    }
+  });
+  
+  eventStream.on('end', () => {
+    console.log('event request ended');
+  });
+}
+

--- a/backend/src/actions/docker/startContainerMetricsStream.ts
+++ b/backend/src/actions/docker/startContainerMetricsStream.ts
@@ -3,6 +3,7 @@ import { DOCKER_DAEMON_SOCKET_PATH } from '../../constants';
 import { cpuGauge, memoryGauge } from '../../promClient';
 import calculateDockerStats from './calculateDockerStats';
 
+// This is a streaming connection that will close when the container is deleted.
 export default async function startContainerMetricsStream(id: string) {
   const response = await axios.get(`/containers/${id}/stats`, {
     socketPath: DOCKER_DAEMON_SOCKET_PATH,

--- a/backend/src/actions/docker/startContainerMetricsStream.ts
+++ b/backend/src/actions/docker/startContainerMetricsStream.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import { DOCKER_DAEMON_SOCKET_PATH } from '../../constants';
+import { cpuGauge, memoryGauge } from '../../promClient';
+import calculateDockerStats from './calculateDockerStats';
+
+export default async function startContainerMetricsStream(id: string) {
+  const response = await axios.get(`/containers/${id}/stats`, {
+    socketPath: DOCKER_DAEMON_SOCKET_PATH,
+    params: { all: true },
+    responseType: 'stream',
+  });
+
+  const stream = response.data;
+
+  stream.on('data', (data: Buffer) => {
+    const stats = JSON.parse(data.toString());
+    // Calculate the CPU % and MEM %
+    // If the container is stopped, these values will be NaN
+    const { cpu_usage_percent, memory_usage_percent } = calculateDockerStats(stats);
+    // Set the metrics gauges of the prometheus client
+    cpuGauge.labels({ id }).set(cpu_usage_percent);
+    memoryGauge.labels({ id }).set(memory_usage_percent);
+  });
+
+  stream.on('end', () => {
+    console.log(`Stream ended for ${id} stats`);
+  });
+}

--- a/backend/src/actions/grafana/createPromQLQueries.ts
+++ b/backend/src/actions/grafana/createPromQLQueries.ts
@@ -1,4 +1,4 @@
-import { QueryStringPanelID } from "../../types";
+import { QueryStringPanelID } from '../../types';
 
 // Create a function that returns an an array of queryStrings.
 // Allows space for additional queries.

--- a/backend/src/actions/grafana/getGrafanaDatasource.ts
+++ b/backend/src/actions/grafana/getGrafanaDatasource.ts
@@ -8,7 +8,7 @@ export default async function getGrafanaDatasource(): Promise<GrafanaDatasource>
 
   // Axios parses data for you in the response
   // This line is unnecessary. It is simply here for readability.
-  const datasourceData: GrafanaDatasourceResponse[] = datasourceResponse.data
+  const datasourceData: GrafanaDatasourceResponse[] = datasourceResponse.data;
 
   // Create a datasource object to be used within panels.
   const datasource: GrafanaDatasource = {

--- a/backend/src/actions/grafana/getGrafanaDatasource.ts
+++ b/backend/src/actions/grafana/getGrafanaDatasource.ts
@@ -1,14 +1,16 @@
-import { GrafanaDatasource } from '../../types';
+import { GrafanaDatasource, GrafanaDatasourceResponse } from '../../types';
+import axios from 'axios';
 
 export default async function getGrafanaDatasource(): Promise<GrafanaDatasource> {
-  // fetch datasource information from grafana API.
-  // this datasource is PRECONFIGURED on launch using grafana config
-  const datasourceResponse: any = await fetch('http://host.docker.internal:2999/api/datasources');
+  // Fetch datasource information from grafana API.
+  // This datasource is PRECONFIGURED on launch using grafana config.
+  const datasourceResponse = await axios.get('http://host.docker.internal:2999/api/datasources');
 
-  // parse datasource response
-  const datasourceData = await datasourceResponse.json();
+  // Axios parses data for you in the response
+  // This line is unnecessary. It is simply here for readability.
+  const datasourceData: GrafanaDatasourceResponse[] = datasourceResponse.data
 
-  // create a datasource object to be used within panels
+  // Create a datasource object to be used within panels.
   const datasource: GrafanaDatasource = {
     type: datasourceData[0].type,
     uid: datasourceData[0].uid,

--- a/backend/src/actions/startStreamAndCreateDashboard.ts
+++ b/backend/src/actions/startStreamAndCreateDashboard.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import startContainerMetricsStream from './docker/startContainerMetricsStream';
+import createGrafanaDashboardObject from './grafana/createGrafanaDashboardObject';
+import { GrafanaDatasource } from '../types';
+
+
+export default async function startStreamAndCreateDashboard(
+  id: string,
+  containerName: string,
+  datasource: GrafanaDatasource
+) {
+  startContainerMetricsStream(id);
+  const dashboard = createGrafanaDashboardObject(id, containerName, datasource);
+
+  // Post request to Grafana API to create a dashboard using the returned dashboard object.
+  await axios.post(
+    'http://host.docker.internal:2999/api/dashboards/db',
+    JSON.stringify(dashboard),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+}

--- a/backend/src/actions/startStreamAndCreateDashboard.ts
+++ b/backend/src/actions/startStreamAndCreateDashboard.ts
@@ -10,20 +10,28 @@ export default async function startStreamAndCreateDashboard(
   containerName: string,
   datasource: GrafanaDatasource
 ) {
-  startContainerMetricsStream(id);
-  const dashboard = createGrafanaDashboardObject(id, containerName, datasource);
+  try {
+    startContainerMetricsStream(id);
+    const dashboard = createGrafanaDashboardObject(id, containerName, datasource);
 
-  // Post request to Grafana API to create a dashboard using the returned dashboard object.
-  await axios.post(
-    'http://host.docker.internal:2999/api/dashboards/db',
-    JSON.stringify(dashboard),
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
+    // Post request to Grafana API to create a dashboard using the returned dashboard object.
+    const dashboardResponse = await axios.post(
+      'http://host.docker.internal:2999/api/dashboards/db',
+      JSON.stringify(dashboard),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if(dashboardResponse.status >= 400) {
+      console.log('Error with POST request to Grafana Dashboards API. In createGrafanaDashboardObject.')
     }
-  );
-  
-  // A simple console log to show when graphs are done being posted to Grafana.
-  console.log(`📊 Grafana graphs 📊 for the ${containerName} container are ready!!`);
+
+    // A simple console log to show when graphs are done being posted to Grafana.
+    console.log(`📊 Grafana graphs 📊 for the ${containerName} container are ready!!`);
+  } catch (err) {
+    console.log(err);
+  }
 }

--- a/backend/src/actions/startStreamAndCreateDashboard.ts
+++ b/backend/src/actions/startStreamAndCreateDashboard.ts
@@ -25,6 +25,7 @@ export default async function startStreamAndCreateDashboard(
       }
     );
 
+    // Descriptive error log for developers
     if (dashboardResponse.status >= 400) {
       console.log(
         'Error with POST request to Grafana Dashboards API. In createGrafanaDashboardObject.'

--- a/backend/src/actions/startStreamAndCreateDashboard.ts
+++ b/backend/src/actions/startStreamAndCreateDashboard.ts
@@ -3,7 +3,8 @@ import startContainerMetricsStream from './docker/startContainerMetricsStream';
 import createGrafanaDashboardObject from './grafana/createGrafanaDashboardObject';
 import { GrafanaDatasource } from '../types';
 
-
+// Function that aggregates container info needed to get metrics and make dashboards.
+// Uses relevant container info and starts a metrics stream and creates a Grafana dashboard.
 export default async function startStreamAndCreateDashboard(
   id: string,
   containerName: string,

--- a/backend/src/actions/startStreamAndCreateDashboard.ts
+++ b/backend/src/actions/startStreamAndCreateDashboard.ts
@@ -23,4 +23,7 @@ export default async function startStreamAndCreateDashboard(
       },
     }
   );
+  
+  // A simple console log to show when graphs are done being posted to Grafana.
+  console.log(`📊 Grafana graphs 📊 for the ${containerName} container are ready!!`);
 }

--- a/backend/src/actions/startStreamAndCreateDashboard.ts
+++ b/backend/src/actions/startStreamAndCreateDashboard.ts
@@ -25,8 +25,10 @@ export default async function startStreamAndCreateDashboard(
       }
     );
 
-    if(dashboardResponse.status >= 400) {
-      console.log('Error with POST request to Grafana Dashboards API. In createGrafanaDashboardObject.')
+    if (dashboardResponse.status >= 400) {
+      console.log(
+        'Error with POST request to Grafana Dashboards API. In createGrafanaDashboardObject.'
+      );
     }
 
     // A simple console log to show when graphs are done being posted to Grafana.

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -14,6 +14,24 @@ export type GrafanaDashboard = {
   overwrite: boolean;
 };
 
+export type GrafanaDatasourceResponse = {
+  id: number;
+  uid: string;
+  orgId: number;
+  name: string;
+  type: string;
+  typeName: string;
+  typeLogoUrl: string;
+  access: string;
+  url: string;
+  user: string;
+  database: string;
+  basicAuth: boolean;
+  isDefault: true;
+  jsonData: {};
+  readOnly: false;
+}
+
 export type GrafanaDatasource = {
   type: string;
   uid: string;


### PR DESCRIPTION
## Overview

**Backend file structure**
- Move HTTP requests into separate files
- Create a small function that starts a metrics stream AND creates a Grafana graph
  - Not 100% sure of the placement of this file so it currently lives in actions
 
**Docker Events Listener**
- Welcome back!
- Similar functionality as before but now using Axios.
- Add feature to create graphs and start metrics stream when a container starts

We can clearly see in the logs that a container has been destroyed and a new one has started:
![image](https://github.com/oslabs-beta/DockerPulse/assets/39440819/d3d9d949-2837-4dda-9223-ef05219d5ff2)

Here we see (after a few minutes of running) graphs with stats being properly displayed in our stats page!
![image](https://github.com/oslabs-beta/DockerPulse/assets/39440819/6396a5e1-1f37-448e-bc5d-1e66bfa4ca35)
