### PR TITLE
Styles: Container name on Logs page

### DIFF
--- a/ui/src/components/FilterDrawer/FilterDrawer.tsx
+++ b/ui/src/components/FilterDrawer/FilterDrawer.tsx
@@ -172,10 +172,10 @@ export default function FilterDrawer({
                       whiteSpace: 'nowrap',
                       textOverflow: 'ellipsis',
                       overflow: 'hidden',
-                      fontFamily: 'monospace',
                       backgroundColor: containerLabelColor[Id],
                       borderRadius: '5px',
-                      padding: 0.5,
+                      px: 1,
+                      my: 0.25,
                     }}
                   >
                     {Names[0].replace(/^\//, '')}

--- a/ui/src/components/LogsRow/LogsRow.tsx
+++ b/ui/src/components/LogsRow/LogsRow.tsx
@@ -54,10 +54,9 @@ export default function LogsRow({
                 whiteSpace: 'nowrap',
                 textOverflow: 'ellipsis',
                 overflow: 'hidden',
-                fontFamily: 'monospace',
                 backgroundColor: labelColor,
                 borderRadius: '5px',
-                padding: 0.5,
+                px: 1,
               }}
             >
               {containerName}
@@ -97,12 +96,9 @@ export default function LogsRow({
                 border: 'lightgray',
                 backgroundColor: theme.palette.background.default,
                 borderRadius: '5px',
-                paddingTop: 0.5,
-                paddingBottom: 0.5,
-                paddingLeft: 1,
-                paddingRight: 1,
-                marginTop: 1,
-                marginBottom: 1,
+                py: 0.5,
+                px: 1,
+                my: 1,
               }}
             >
               <Typography sx={{ fontFamily: 'monospace', whiteSpace: 'pre' }}>


### PR DESCRIPTION
## Overview

Previously, there was virtually no margin between the colored background of container names. By making the font sans-serif instead of mono and adding some padding, the container names are more compact and still very legible. 

Container names are rendered with sans-serif font elsewhere in the Docker Desktop app.

This change is made on both the Logs page table and the FilterDrawer component:

### Before
![Screenshot 2023-06-30 at 3 18 13 PM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/2a7322ed-6066-4ceb-a030-385cb08f38b2)

### After
![Screenshot 2023-06-30 at 3 15 17 PM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/7beecd95-5563-4e17-bd80-b9ea0552903a)


