### PR TITLE
Ensure shared volumes populate with the correct config files by using the depends_on setting

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,19 +6,15 @@ services:
     container_name: dockerpulse
     volumes:
       - /var/run/docker.sock.raw:/var/run/docker.sock
-      # Create a named volume which is mapped to the /grafana folder in the extension container
-      # (The /grafana folder is added to the extension container in the extension's Dockerfile)
+      # Create named volumes which are mapped to the /grafana & /prometheus folder in the extension container
+      # (The /grafana & /prometheus folder is added to the extension container in the extension's Dockerfile)
       - shared-grafana-files:/grafana
-      # Create a named volume which is mapped to the /prometheus folder in the extension container
-      # (The /prometheus folder is added to the extension container in the extension's Dockerfile)
       - shared-prometheus-files:/prometheus
     ports:
       # Expose port 3333 to the host so that you can see metrics on localhost:3333/metrics
       - 3333:3333
 
   prometheus:
-    # Pulling a custom image that has been pushed to the hub that has been configured to scrape
-    # from cadvisor so there is no need to create a bind mount that configures the prometheus.yml file
     image: prom/prometheus:latest
     container_name: prometheus
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 # Use the Docker socket from the extension backend:
 # https://docs.docker.com/desktop/extensions-sdk/guides/use-docker-socket-from-backend/
 services:
-  myExtension:
+  DockerPulse:
     image: ${DESKTOP_PLUGIN_IMAGE}
     container_name: dockerpulse
     volumes:
@@ -31,7 +31,7 @@ services:
       # Share the named volume with the prometheus container
       - shared-prometheus-files:/etc/prometheus
     depends_on:
-      - myExtension
+      - DockerPulse
 
   grafana:
     image: grafana/grafana:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
       - prometheusdata:/prometheus
       # Share the named volume with the prometheus container
       - shared-prometheus-files:/etc/prometheus
+    depends_on:
+      - myExtension
 
   grafana:
     image: grafana/grafana:latest


### PR DESCRIPTION
- add "depends_on: 'DockerPulse'" property to the Prometheus image within the docker compose file to ensure DockerPulse gets built first so shared volumes populate with the correct config files and aren't overwritten with the default config settings