### PR TITLE
Metrics show on LogsRow!

### DIFF
--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -1,88 +1,78 @@
-import axios from "axios";
-import { Request, Response, NextFunction } from "express";
+import axios from 'axios';
+import { Request, Response, NextFunction } from 'express';
 
-const metricsController = function() {};
+// interface QueryResultObject {
+//   metric: Object;
+//   value: [number, 'NaN' | string]
 
-metricsController.getCPUMetrics = async (req: Request, res: Response, next: NextFunction) => {
-  try{
-    const { containerID, time } = req.body;
+// }
 
-    if(!containerID || !time) {
-      // return error
+const metricsController = {
+  getCPUMetrics: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { containerID, time } = req.body.promQLBody;
+      console.log('------------------in get cpu metrics------------------');
+
+      // if (!containerID || !time) {
+      //   // return error
+      // }
+      res.locals.metrics = {};
+
+      const CPU_QUERY_STRING = `rate(cpu_usage_percent{id="${containerID}"}[10s])&time=${time}`;
+      const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${CPU_QUERY_STRING}`;
+
+      const prometheusResponse = await axios.get(PROMQL_URL);
+
+      const queryValue =
+        prometheusResponse.data.data.result.length === 0
+          ? 0
+          : parseInt(prometheusResponse.data.data.result[0].value[1]);
+      console.log('queryValue', queryValue);
+
+      const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
+      console.log('CPU query value rounded', queryValueRounded);
+
+      res.locals.metrics = {};
+      res.locals.metrics['CPU'] = queryValueRounded;
+
+      return next();
+    } catch (err) {
+      console.error(err);
     }
+  },
 
-    const CPU_QUERY_STRING = `rate(cpu_usage_percent{id="${containerID}"}[10s])&time=${time}`
-    const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${CPU_QUERY_STRING}`
+  getMEMMetrics: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { containerID, time } = req.body.promQLBody;
+      console.log('------------------in get cpu metrics------------------');
 
+      // if (!containerID || !time) {
+      //   //return error
+      // }
+      console.log(containerID, time);
+      const RAM_QUERY_STRING = `avg(memory_usage_percent{id='${containerID}'})&time=${time}`;
+      const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${RAM_QUERY_STRING}`;
 
+      const prometheusResponse = await axios.get(PROMQL_URL);
 
-    const prometheusResponse = await axios.get(PROMQL_URL);
-    console.log('prometheusResponse', prometheusResponse);
-    const queryValue = parseInt(prometheusResponse.data.result[0].value[1]);
-    console.log('queryValue', queryValue);
-    
-    res.locals.metrics = {};
-    res.locals.metrics['CPU'] = queryValue;
+      const queryValue =
+        prometheusResponse.data.data.result.length === 0
+          ? 0
+          : parseInt(prometheusResponse.data.data.result[0].value[1]);
+      console.log('queryValue', queryValue);
 
-    return next();
-  } catch (err) {
-    console.error(err);
-  }
-}
+      const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
+      console.log('MEM query value rounded', queryValueRounded);
 
-metricsController.getMEMMetrics = async (res: Response, req: Request, next: NextFunction) => {
-   
-  try{
-    const { containerID, time } = req.body;
-    if(!containerID || !time){
-      //return error
+      res.locals.metrics['MEM'] = queryValueRounded;
+
+      return next();
+    } catch (err) {
+      console.error(err);
     }
-
-    const RAM_QUERY_STRING = `avg(memory_usage_percent{id='${containerID}'})&time=${time}`
-    const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${RAM_QUERY_STRING}`
-
-    const prometheusResponse = await axios.get(PROMQL_URL);
-    console.log('RAM prometheus response', prometheusResponse)
-    const queryValue: any = parseInt(prometheusResponse.data.result[0].value[1]);
-    console.log('RAM query value', queryValue);
-    const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
-    console.log('RAM query value rounded', queryValueRounded);
-
-
-    res.locals.metrics = {};
-    res.locals.metrics['MEM'] = queryValueRounded;
-  }
-  catch(err){
-    console.error(err);
-  }
-}
-
+  },
+};
 // Conversion for front end
 // const promTime = (Date.parse(time) / 1000).toFixed(3);
 
-// {
-//   CPU: number
-//   MEM: number
-//   NETIO: number
-// }
-
 export default metricsController;
-
-
-    /*
-    {
-      status: string,
-      data: {
-        resultType: string,
-        result: [
-          {
-            metric: {},
-            value: [
-              UNIX_TIMESTAMP,
-              VALUE
-            ]
-          }
-        ]
-      }
-    }
-    */

--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -62,7 +62,5 @@ const metricsController = {
     }
   },
 };
-// Conversion for front end
-// const promTime = (Date.parse(time) / 1000).toFixed(3);
 
 export default metricsController;

--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -1,0 +1,57 @@
+const metricsController = {};
+
+metricsController.getCPUMetrics = async (req, res, next) => {
+  try{
+    const { containerID, time } = req.body;
+
+    if(!containerID || !time) {
+      //return error
+    }
+
+    res.locals.metrics = {};
+    res.locals.metrics['CPU'] = null // PROMQL FETCH HERE
+
+  } catch (err) {
+
+  }
+}
+
+
+
+metricsController.getMEMMetrics = async (res, req, next) => {
+  
+  try{
+    const { containerID, time } = req.body;
+    if(!containerID || !time){
+      
+    }
+    
+  }
+  catch(err){
+
+  }
+}
+
+
+metricsController.getNETIOMetrics = async (res, req, next) => {
+  
+  try{
+    const { containerID, time } = req.body;
+    if(!containerID || !time){
+      
+    }
+    
+    res.locals.metrics['NETIO'] = null // PROMQL FETCH HERE
+  }
+  catch(err){
+
+  }
+}
+
+// {
+//   CPU: number
+//   MEM: number
+//   NETIO: number
+// }
+
+export default metricsController;

--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -7,28 +7,29 @@ const metricsController = {
   getCPUMetrics: async (req: Request, res: Response, next: NextFunction) => {
     try {
       // Destructure req.body.promQLBody to get variables from the frontend.
-      const { containerID, time } = req.body.promQLBody;
+      const { containerID, time } = req.query;
 
       // Construct the query string for CPU % and the GET request URL for Prometheus API.
-      const CPU_QUERY_STRING = `rate(cpu_usage_percent{id="${containerID}"}[10s])&time=${time}`;
-      const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${CPU_QUERY_STRING}`;
+      const CPUQueryParam = `rate(cpu_usage_percent{id="${containerID}"}[10s])`
 
       // Make GET request to Prometheus API and store result in an accessible const.
-      const prometheusResponse = await axios.get(PROMQL_URL);
+      const prometheusResponse = await axios.get('http://host.docker.internal:9090/api/v1/query',{
+        params: {
+          query: CPUQueryParam,
+          time: time
+        }
+      });
       const queryResult = prometheusResponse.data.data.result;
 
       // Set value equal to either 0 (No result from Prometheus) or the result from Prometheus.
-      const queryValue = queryResult.length ? queryResult[0].value[1] : 0;
-
-      // Round value to two decimal places.
-      const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
+      const queryValue = queryResult.length ? queryResult[0].value[1] : 'NaN';
 
       // If more metrics are added in the future, ensure that this middleware is called first!
       // Create an empty object to be passed down through res.locals.
       res.locals.metrics = {};
 
       // Set the key of CPU equal to the rounded, formatted query value.
-      res.locals.metrics['CPU'] = queryValueRounded;
+      res.locals.metrics['CPU'] = queryValue;
       return next();
     } catch (err) {
       console.error(err);
@@ -38,24 +39,25 @@ const metricsController = {
   getMEMMetrics: async (req: Request, res: Response, next: NextFunction) => {
     try {
       // Destructure req.body.promQLBody to get variables from the frontend.
-      const { containerID, time } = req.body.promQLBody;
+      const { containerID, time } = req.query;
 
       // Construct the query string for MEM % and the GET request URL for Prometheus API.
-      const RAM_QUERY_STRING = `avg(memory_usage_percent{id='${containerID}'})&time=${time}`;
-      const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${RAM_QUERY_STRING}`;
+      const MEMQueryParam = `avg(memory_usage_percent{id='${containerID}'})`
 
       // Make GET request to Prometheus API and store result in an accessible const.
-      const prometheusResponse = await axios.get(PROMQL_URL);
+      const prometheusResponse = await axios.get('http://host.docker.internal:9090/api/v1/query',{
+        params: {
+          query: MEMQueryParam,
+          time: time
+        }
+      });
       const queryResult = prometheusResponse.data.data.result;
 
       // Set value equal to either 0 (No result from Prometheus) or the result from Prometheus.
-      const queryValue = queryResult.length ? queryResult[0].value[1] : 0;
-
-      // Round value to two decimal places.
-      const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
+      const queryValue = queryResult.length ? queryResult[0].value[1] : 'NaN';
 
       // Set the key of MEM equal to the rounded, formatted query value.
-      res.locals.metrics['MEM'] = queryValueRounded;
+      res.locals.metrics['MEM'] = queryValue;
       return next();
     } catch (err) {
       console.error(err);

--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -18,7 +18,7 @@ const metricsController = {
       const queryResult = prometheusResponse.data.data.result;
 
       // Set value equal to either 0 (No result from Prometheus) or the result from Prometheus.
-      const queryValue = queryResult.length === 0 ? 0 : parseInt(queryResult[0].value[1]);
+      const queryValue = queryResult.length ? queryResult[0].value[1] : 0;
 
       // Round value to two decimal places.
       const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
@@ -49,7 +49,7 @@ const metricsController = {
       const queryResult = prometheusResponse.data.data.result;
 
       // Set value equal to either 0 (No result from Prometheus) or the result from Prometheus.
-      const queryValue = queryResult.length === 0 ? 0 : parseInt(queryResult[0].value[1]);
+      const queryValue = queryResult.length ? queryResult[0].value[1] : 0;
 
       // Round value to two decimal places.
       const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);

--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -1,50 +1,43 @@
-const metricsController = {};
+import axios from "axios";
+import { Request, Response, NextFunction } from "express";
 
-metricsController.getCPUMetrics = async (req, res, next) => {
+const metricsController = function() {};
+
+metricsController.getCPUMetrics = async (req: Request, res: Response, next: NextFunction) => {
   try{
     const { containerID, time } = req.body;
 
     if(!containerID || !time) {
-      //return error
+      // return error
     }
+
+    const CPU_QUERY_STRING = `avg(memory_usage_percent{${containerID}})&time=${time}`
+    const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${CPU_QUERY_STRING}`
+
+    const prometheusResponse = await axios.get(PROMQL_URL);
+
 
     res.locals.metrics = {};
-    res.locals.metrics['CPU'] = null // PROMQL FETCH HERE
+    res.locals.metrics['CPU'] = prometheusResponse.data.result
 
+    return next();
   } catch (err) {
-
+    console.error(err);
   }
 }
 
-
-
-metricsController.getMEMMetrics = async (res, req, next) => {
-  
+metricsController.getMEMMetrics = async (res: Response, req: Request, next: NextFunction) => {
+   
   try{
     const { containerID, time } = req.body;
     if(!containerID || !time){
-      
+      //return error
     }
-    
+    res.locals.metrics = {};
+    res.locals.metrics['MEM'] = null // PROMQL FETCH HERE
   }
   catch(err){
-
-  }
-}
-
-
-metricsController.getNETIOMetrics = async (res, req, next) => {
-  
-  try{
-    const { containerID, time } = req.body;
-    if(!containerID || !time){
-      
-    }
-    
-    res.locals.metrics['NETIO'] = null // PROMQL FETCH HERE
-  }
-  catch(err){
-
+    console.error(err);
   }
 }
 
@@ -55,3 +48,22 @@ metricsController.getNETIOMetrics = async (res, req, next) => {
 // }
 
 export default metricsController;
+
+
+    /*
+    {
+      status: string,
+      data: {
+        resultType: string,
+        result: [
+          {
+            metric: {},
+            value: [
+              UNIX_TIMESTAMP,
+              VALUE
+            ]
+          }
+        ]
+      }
+    }
+    */

--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -1,40 +1,34 @@
 import axios from 'axios';
 import { Request, Response, NextFunction } from 'express';
 
-// interface QueryResultObject {
-//   metric: Object;
-//   value: [number, 'NaN' | string]
-
-// }
-
+// Controller object for Metrics. Contains middleware that gets metrics at a passed in
+// timestamp and creates an object with key-value pairs (Metric Type and Metric Value)
 const metricsController = {
   getCPUMetrics: async (req: Request, res: Response, next: NextFunction) => {
     try {
+      // Destructure req.body.promQLBody to get variables from the frontend.
       const { containerID, time } = req.body.promQLBody;
-      console.log('------------------in get cpu metrics------------------');
 
-      // if (!containerID || !time) {
-      //   // return error
-      // }
-      res.locals.metrics = {};
-
+      // Construct the query string for CPU % and the GET request URL for Prometheus API.
       const CPU_QUERY_STRING = `rate(cpu_usage_percent{id="${containerID}"}[10s])&time=${time}`;
       const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${CPU_QUERY_STRING}`;
 
+      // Make GET request to Prometheus API and store result in an accessible const.
       const prometheusResponse = await axios.get(PROMQL_URL);
+      const queryResult = prometheusResponse.data.data.result;
 
-      const queryValue =
-        prometheusResponse.data.data.result.length === 0
-          ? 0
-          : parseInt(prometheusResponse.data.data.result[0].value[1]);
-      console.log('queryValue', queryValue);
+      // Set value equal to either 0 (No result from Prometheus) or the result from Prometheus.
+      const queryValue = queryResult.length === 0 ? 0 : parseInt(queryResult[0].value[1]);
 
+      // Round value to two decimal places.
       const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
-      console.log('CPU query value rounded', queryValueRounded);
 
+      // If more metrics are added in the future, ensure that this middleware is called first!
+      // Create an empty object to be passed down through res.locals.
       res.locals.metrics = {};
-      res.locals.metrics['CPU'] = queryValueRounded;
 
+      // Set the key of CPU equal to the rounded, formatted query value.
+      res.locals.metrics['CPU'] = queryValueRounded;
       return next();
     } catch (err) {
       console.error(err);
@@ -43,29 +37,25 @@ const metricsController = {
 
   getMEMMetrics: async (req: Request, res: Response, next: NextFunction) => {
     try {
+      // Destructure req.body.promQLBody to get variables from the frontend.
       const { containerID, time } = req.body.promQLBody;
-      console.log('------------------in get cpu metrics------------------');
 
-      // if (!containerID || !time) {
-      //   //return error
-      // }
-      console.log(containerID, time);
+      // Construct the query string for MEM % and the GET request URL for Prometheus API.
       const RAM_QUERY_STRING = `avg(memory_usage_percent{id='${containerID}'})&time=${time}`;
       const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${RAM_QUERY_STRING}`;
 
+      // Make GET request to Prometheus API and store result in an accessible const.
       const prometheusResponse = await axios.get(PROMQL_URL);
+      const queryResult = prometheusResponse.data.data.result;
 
-      const queryValue =
-        prometheusResponse.data.data.result.length === 0
-          ? 0
-          : parseInt(prometheusResponse.data.data.result[0].value[1]);
-      console.log('queryValue', queryValue);
+      // Set value equal to either 0 (No result from Prometheus) or the result from Prometheus.
+      const queryValue = queryResult.length === 0 ? 0 : parseInt(queryResult[0].value[1]);
 
+      // Round value to two decimal places.
       const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
-      console.log('MEM query value rounded', queryValueRounded);
 
+      // Set the key of MEM equal to the rounded, formatted query value.
       res.locals.metrics['MEM'] = queryValueRounded;
-
       return next();
     } catch (err) {
       console.error(err);

--- a/backend/src/controllers/metricsController.ts
+++ b/backend/src/controllers/metricsController.ts
@@ -11,14 +11,18 @@ metricsController.getCPUMetrics = async (req: Request, res: Response, next: Next
       // return error
     }
 
-    const CPU_QUERY_STRING = `avg(memory_usage_percent{${containerID}})&time=${time}`
+    const CPU_QUERY_STRING = `rate(cpu_usage_percent{id="${containerID}"}[10s])&time=${time}`
     const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${CPU_QUERY_STRING}`
 
+
+
     const prometheusResponse = await axios.get(PROMQL_URL);
-
-
+    console.log('prometheusResponse', prometheusResponse);
+    const queryValue = parseInt(prometheusResponse.data.result[0].value[1]);
+    console.log('queryValue', queryValue);
+    
     res.locals.metrics = {};
-    res.locals.metrics['CPU'] = prometheusResponse.data.result
+    res.locals.metrics['CPU'] = queryValue;
 
     return next();
   } catch (err) {
@@ -33,13 +37,28 @@ metricsController.getMEMMetrics = async (res: Response, req: Request, next: Next
     if(!containerID || !time){
       //return error
     }
+
+    const RAM_QUERY_STRING = `avg(memory_usage_percent{id='${containerID}'})&time=${time}`
+    const PROMQL_URL = `http://host.docker.internal:9090/api/v1/query?query=${RAM_QUERY_STRING}`
+
+    const prometheusResponse = await axios.get(PROMQL_URL);
+    console.log('RAM prometheus response', prometheusResponse)
+    const queryValue: any = parseInt(prometheusResponse.data.result[0].value[1]);
+    console.log('RAM query value', queryValue);
+    const queryValueRounded = (Math.round(queryValue * 100) / 100).toFixed(2);
+    console.log('RAM query value rounded', queryValueRounded);
+
+
     res.locals.metrics = {};
-    res.locals.metrics['MEM'] = null // PROMQL FETCH HERE
+    res.locals.metrics['MEM'] = queryValueRounded;
   }
   catch(err){
     console.error(err);
   }
 }
+
+// Conversion for front end
+// const promTime = (Date.parse(time) / 1000).toFixed(3);
 
 // {
 //   CPU: number

--- a/backend/src/extensionServer.ts
+++ b/backend/src/extensionServer.ts
@@ -3,42 +3,24 @@ import metricsController from './controllers/metricsController';
 
 const app = express();
 
+// Body parsers
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// Simple endpoint to test backend connectivity
 app.get('/hello', (req, res) => {
   console.log('ouch', Date.now());
   res.send('hello world from the server');
 });
 
-app.post('/api/promQL',
-  (req,res,next) => {
-    console.log('in the backend!');
-    return next();
-  },
+// Post request handler for endpoint /api/promQL
+app.post(
+  '/api/promQL',
   metricsController.getCPUMetrics,
   metricsController.getMEMMetrics,
-  (req, res) => {
+  (_req, res) => {
     return res.status(200).json(res.locals.metrics);
   }
-)
+);
 
 export default app;
-
-/*
-
-BODY: {
-  containerID: 'string'
-  time: Date.now() format <-- unix time
-}
-
-try {
-  const response = (await ddClient.extension.vm?.service?.post(
-    '/api/promQL',
-    { BODY }
-  ))
-} catch (err) {
-  console.log(err)
-}
-
-*/

--- a/backend/src/extensionServer.ts
+++ b/backend/src/extensionServer.ts
@@ -1,19 +1,27 @@
 import express from 'express';
+import metricsController from './controllers/metricsController';
 
 const app = express();
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 app.get('/hello', (req, res) => {
   console.log('ouch', Date.now());
   res.send('hello world from the server');
 });
 
-// app.post('/api/promQL',
-//   getCPUMetrics.metricsController,
-//   getMEMMetrics.metricsController,
-//   (req, res) => {
-//     return res.status(200).json(res.locals.idk);
-//   }
-// )
+app.post('/api/promQL',
+  (req,res,next) => {
+    console.log('in the backend!');
+    return next();
+  },
+  metricsController.getCPUMetrics,
+  metricsController.getMEMMetrics,
+  (req, res) => {
+    return res.status(200).json(res.locals.metrics);
+  }
+)
 
 export default app;
 

--- a/backend/src/extensionServer.ts
+++ b/backend/src/extensionServer.ts
@@ -7,4 +7,30 @@ app.get('/hello', (req, res) => {
   res.send('hello world from the server');
 });
 
+app.post('/api/promQL',
+  getCPUMetrics.metricsController,
+  getMEMMetrics.metricsController,
+  (req, res) => {
+    return res.status(200).json(res.locals.idk);
+  }
+)
+
 export default app;
+
+/*
+
+BODY: {
+  containerID: 'string'
+  time: Date.now() format <-- unix time
+}
+
+try {
+  const response = (await ddClient.extension.vm?.service?.post(
+    '/api/promQL',
+    { BODY }
+  ))
+} catch (err) {
+  console.log(err)
+}
+
+*/

--- a/backend/src/extensionServer.ts
+++ b/backend/src/extensionServer.ts
@@ -7,13 +7,13 @@ app.get('/hello', (req, res) => {
   res.send('hello world from the server');
 });
 
-app.post('/api/promQL',
-  getCPUMetrics.metricsController,
-  getMEMMetrics.metricsController,
-  (req, res) => {
-    return res.status(200).json(res.locals.idk);
-  }
-)
+// app.post('/api/promQL',
+//   getCPUMetrics.metricsController,
+//   getMEMMetrics.metricsController,
+//   (req, res) => {
+//     return res.status(200).json(res.locals.idk);
+//   }
+// )
 
 export default app;
 

--- a/backend/src/extensionServer.ts
+++ b/backend/src/extensionServer.ts
@@ -13,8 +13,9 @@ app.get('/hello', (req, res) => {
   res.send('hello world from the server');
 });
 
-// Post request handler for endpoint /api/promQL
-app.post(
+// GET request handler for endpoint /api/promQL.
+// Expects query parameters for containerID and time.
+app.get(
   '/api/promQL',
   metricsController.getCPUMetrics,
   metricsController.getMEMMetrics,

--- a/ui/src/components/LogsRow/LogsRow.tsx
+++ b/ui/src/components/LogsRow/LogsRow.tsx
@@ -46,7 +46,7 @@ export default function LogsRow({
       });
 
       // Create a display string using the provided response from our backend.
-      const newMetricsString = `CPU %: ${response.CPU} MEM %: ${response.MEM}`
+      const newMetricsString = `CPU %: ${response.CPU} MEM %: ${response.MEM}`;
 
       // Set metrics to display metrics at the time of the log!
       setMetrics(newMetricsString);
@@ -54,26 +54,6 @@ export default function LogsRow({
       console.error(err);
     }
   };
-
-  /*
-
-BODY: {
-  containerID: 'string'
-  time: Date.now() format <-- unix time
-}
-
-try {
-  const response = (await ddClient.extension.vm?.service?.post(
-    '/api/promQL',
-    { BODY }
-  ))
-} catch (err) {
-  console.log(err)
-}
-
-*/
-
-  // Conversion for front end
 
   return (
     <>

--- a/ui/src/components/LogsRow/LogsRow.tsx
+++ b/ui/src/components/LogsRow/LogsRow.tsx
@@ -46,7 +46,7 @@ export default function LogsRow({
       });
 
       // Create a display string using the provided response from our backend.
-      const newMetricsString = `CPU %: ${response.CPU} MEM %: ${response.MEM}`;
+      const newMetricsString = `CPU: ${response.CPU}% MEM: ${response.MEM}%`;
 
       // Set metrics to display metrics at the time of the log!
       setMetrics(newMetricsString);

--- a/ui/src/components/LogsRow/LogsRow.tsx
+++ b/ui/src/components/LogsRow/LogsRow.tsx
@@ -25,32 +25,31 @@ export default function LogsRow({
 }) {
   const { containerId, containerName, time, stream, log } = logInfo;
   const [open, setOpen] = useState<boolean>(false);
-  const [dummyData, setDummyData] = useState('');
+  const [metrics, setMetrics] = useState('');
 
   const labelColor = containerLabelColor[containerId];
   let iconColor = containerIconColor[containerId] === 'running' ? 'teal' : 'grey';
 
   const fetchMetrics = async (ddClient: DDClient) => {
-    // Skeleton for response
     try {
+      // Parse time into Prometheus API friendly format
       const promTime = (Date.parse(time) / 1000).toFixed(3);
+      // Create an object to be passed into our backend
       const promQLBody = {
         containerID: containerId,
         time: promTime,
       };
 
-      console.log(promQLBody);
+      // POST request to the backend via the ddClient.
       const response: any = await ddClient.extension.vm?.service?.post('/api/promQL', {
         promQLBody,
       });
-      console.log(response);
-      
-      const newMetricsString = `CPU %: ${response.CPU} MEM %: ${response.MEM}`
-      console.log(newMetricsString);
 
-      setDummyData(newMetricsString);
-      // setDummyData('hello world');
-      console.log('im working');
+      // Create a display string using the provided response from our backend.
+      const newMetricsString = `CPU %: ${response.CPU} MEM %: ${response.MEM}`
+
+      // Set metrics to display metrics at the time of the log!
+      setMetrics(newMetricsString);
     } catch (err) {
       console.error(err);
     }
@@ -144,7 +143,7 @@ try {
             timeout="auto"
             unmountOnExit
           >
-            <Typography sx={{ display: 'flex', fontSize: '11px' }}>{dummyData}</Typography>
+            <Typography sx={{ display: 'flex', fontSize: '11px' }}>{metrics}</Typography>
             <Box
               sx={{
                 display: 'flex',

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -222,6 +222,7 @@ export default function Logs() {
                   logInfo={logInfo}
                   containerLabelColor={containerLabelColor}
                   containerIconColor={containerIconColor}
+                  ddClient={ddClient}
                 />
               ))}
             </TableBody>


### PR DESCRIPTION
## Overview

**Frontend**
- Metrics will appear in the LogsRow on click!
  - Show CPU% and RAM%
  - Make a POST request to the backend via ddClient
  
**Backend**
- Route handler added to extensionServer.ts
- Controller to handle metrics fetching from Prometheus API added
  - PromQL queries for CPU% and MEM% added to each function in the controller
  - Returns an object with promQL data to the frontend
  
![image](https://github.com/oslabs-beta/DockerPulse/assets/39440819/730370a8-193d-4fb8-9311-2924ef497c03)

**BUGFIX**
- The ternary operator was not functioning properly and always returning 0.
- Now it properly chooses 0 if there is no data, or the data if there is data.

## Addressing comments

![image](https://github.com/oslabs-beta/DockerPulse/assets/39440819/bf56a293-d655-4d57-ad2b-2252cbf127d6)
![image](https://github.com/oslabs-beta/DockerPulse/assets/39440819/d50192bd-ba62-4d7a-9537-783322c6b2d7)

- Remove improper usage of constants, change to camelCase.
- Add params key to axios.get request in metricsController.
- Change POST request to GET request in extensionServer. 
  - Refactor GET request to take query parameters
- Backend sends back exact data and is parsed in the frontend.
  - Also returns NaN instead of 0 for more intuitive display.
- Remove ddClient being passed in as an argument.