### PR TITLE
Add loading icon to logs page

### DIFF
--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -198,46 +198,45 @@ export default function Logs() {
             setElapsedTimeInMinutes={setElapsedTimeInMinutes}
           />
         </Stack>
-
-        <TableContainer
-          component={Paper}
-          sx={{
-            marginTop: 2,
-            flexGrow: 1,
-            background: 'none',
-            border: 'none',
-          }}
-        >
-          <Table size="small" stickyHeader>
-            <TableHead>
-              <TableRow>
-                {HEADERS.map((header) => (
-                  <TableCell>
-                    <Typography sx={{ whiteSpace: 'nowrap', fontWeight: 'bold' }}>
-                      {header}
-                    </Typography>
-                  </TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {isLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', width: '100vw' }}>
-                  <CircularProgress />
-                </Box>
-              ) : (
-                filteredLogs.map((logInfo) => (
+        {isLoading ? (
+          <Box sx={{ p: 4, display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <TableContainer
+            component={Paper}
+            sx={{
+              marginTop: 2,
+              flexGrow: 1,
+              background: 'none',
+              border: 'none',
+            }}
+          >
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  {HEADERS.map((header) => (
+                    <TableCell>
+                      <Typography sx={{ whiteSpace: 'nowrap', fontWeight: 'bold' }}>
+                        {header}
+                      </Typography>
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {filteredLogs.map((logInfo) => (
                   <LogsRow
                     logInfo={logInfo}
                     containerLabelColor={containerLabelColor}
                     containerIconColor={containerIconColor}
                     ddClient={ddClient}
                   />
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
       </Box>
     </>
   );

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -77,6 +77,7 @@ export default function Logs() {
   const [containerLabelColor, setContainerLabelColor] = useState<Record<string, string>>({});
   const [containerIconColor, setContainerIconColor] = useState<Record<string, string>>({});
   const [elapsedTimeInMinutes, setElapsedTimeInMinutes] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
   const [filters, setFilters] = useState<LogFilters>({
     stdout: true,
     stderr: true,
@@ -84,6 +85,7 @@ export default function Logs() {
   });
 
   useEffect(() => {
+    setIsLoading(true);
     refreshAll();
   }, []);
 
@@ -121,6 +123,7 @@ export default function Logs() {
       );
       setContainerIconColor(updatedContainerIconColor);
       setElapsedTimeInMinutes(0);
+      setIsLoading(false);
     } catch (err) {
       console.error(err);
     }
@@ -218,7 +221,7 @@ export default function Logs() {
               </TableRow>
             </TableHead>
             <TableBody>
-              {filteredLogs.length === 0 ? (
+              {isLoading ? (
                 <Box sx={{ display: 'flex', justifyContent: 'center', width: '100vw' }}>
                   <CircularProgress />
                 </Box>

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -3,6 +3,7 @@ import { createDockerDesktopClient } from '@docker/extension-api-client';
 import { Search, Clear, FilterList, Refresh } from '@mui/icons-material';
 import {
   Box,
+  CircularProgress,
   Stack,
   Typography,
   OutlinedInput,
@@ -217,14 +218,20 @@ export default function Logs() {
               </TableRow>
             </TableHead>
             <TableBody>
-              {filteredLogs.map((logInfo) => (
-                <LogsRow
-                  logInfo={logInfo}
-                  containerLabelColor={containerLabelColor}
-                  containerIconColor={containerIconColor}
-                  ddClient={ddClient}
-                />
-              ))}
+              {filteredLogs.length === 0 ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', width: '100vw' }}>
+                  <CircularProgress />
+                </Box>
+              ) : (
+                filteredLogs.map((logInfo) => (
+                  <LogsRow
+                    logInfo={logInfo}
+                    containerLabelColor={containerLabelColor}
+                    containerIconColor={containerIconColor}
+                    ddClient={ddClient}
+                  />
+                ))
+              )}
             </TableBody>
           </Table>
         </TableContainer>

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -85,7 +85,6 @@ export default function Logs() {
   });
 
   useEffect(() => {
-    setIsLoading(true);
     refreshAll();
   }, []);
 
@@ -100,6 +99,7 @@ export default function Logs() {
 
   // Refreshes logs page fetching all new containers
   const refreshAll = async () => {
+    setIsLoading(true);
     try {
       const allContainers = await fetchAllContainers(ddClient);
       const allContainerLogs = await fetchAllContainerLogs(ddClient, allContainers);


### PR DESCRIPTION
### Overview

- Loading icon displays if logs are not yet rendered
- Loading icon displays when user clicks on the refresh logs button
![Screenshot 2023-07-03 at 3 42 01 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/85f3c37f-68ae-4ed9-9d59-ae9e76033855)
