### PR TITLE
Allow user to delete time filter input and display all logs

### DIFF
--- a/ui/src/components/FilterDrawer/FilterDrawer.tsx
+++ b/ui/src/components/FilterDrawer/FilterDrawer.tsx
@@ -46,11 +46,11 @@ export default function FilterDrawer({
 
   // Debounce functions
   const debouncedSetValidFromTimestamp = debounce((value) => {
-    if (isTimestampValid(value)) setValidFromTimestamp(value);
+    isTimestampValid(value) ? setValidFromTimestamp(value) : setValidFromTimestamp('');
   }, 1000);
 
   const debouncedSetValidUntilTimestamp = debounce((value) => {
-    if (isTimestampValid(value)) setValidUntilTimestamp(value);
+    isTimestampValid(value) ? setValidUntilTimestamp(value) : setValidUntilTimestamp('');
   }, 1000);
 
   // Clean up debounce functions if user fires debounce function before the second is up


### PR DESCRIPTION
### Overview:

- Before when a user enters a time range and then deletes it, none of the logs show
- Debounce functions refactored to account for user deleting time range

**User enters a time range filtering out logs**
![Screenshot 2023-07-04 at 1 36 52 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/8324bae4-5e89-4e35-8fc7-0c6e72c7ad1c)

**User deletes time range allowing all logs to come back**
![Screenshot 2023-07-04 at 1 37 56 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/153afc9e-c549-4196-b2a0-ced218893fea)
