### PR TITLE
Filters persist after refreshing logs page

### DIFF
--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -105,7 +105,9 @@ export default function Logs() {
       const allContainerLogs = await fetchAllContainerLogs(ddClient, allContainers);
       setContainers(allContainers);
       setLogs(allContainerLogs);
-      setFilters({ ...filters, allowedContainers: new Set(allContainers.map(({ Id }) => Id)) });
+      filters.allowedContainers.size === 0
+        ? setFilters({ ...filters, allowedContainers: new Set(allContainers.map(({ Id }) => Id)) })
+        : setFilters({ ...filters });
       const updatedContainerLabelColor = allContainers.reduce(
         (prevContainerLabelColor, container, index) => ({
           ...prevContainerLabelColor,

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -103,15 +103,31 @@ export default function Logs() {
     try {
       const allContainers = await fetchAllContainers(ddClient);
       const allContainerLogs = await fetchAllContainerLogs(ddClient, allContainers);
+      // Added new container and filters are applied
+      if (
+        allContainers.length > containers.length &&
+        (filters.allowedContainers.size < containers.length || !filters.stderr || !filters.stdout)
+      ) {
+        setFilters({
+          ...filters,
+          allowedContainers: filters.allowedContainers.add(allContainers[0].Id),
+        });
+      } // If no new containers but filters are applied
+      else if (
+        allContainers.length === containers.length &&
+        (filters.allowedContainers.size < containers.length || !filters.stdout || !filters.stderr)
+      ) {
+        setFilters({ ...filters });
+      } // On initial render as well as if no new containers as well as no filters applied
+      else {
+        setFilters({
+          stdout: true,
+          stderr: true,
+          allowedContainers: new Set(allContainers.map(({ Id }) => Id)),
+        });
+      }
       setContainers(allContainers);
       setLogs(allContainerLogs);
-      filters.allowedContainers.size === 0
-        ? setFilters({
-            stdout: true,
-            stderr: true,
-            allowedContainers: new Set(allContainers.map(({ Id }) => Id)),
-          })
-        : setFilters({ ...filters });
       const updatedContainerLabelColor = allContainers.reduce(
         (prevContainerLabelColor, container, index) => ({
           ...prevContainerLabelColor,

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -106,7 +106,11 @@ export default function Logs() {
       setContainers(allContainers);
       setLogs(allContainerLogs);
       filters.allowedContainers.size === 0
-        ? setFilters({ ...filters, allowedContainers: new Set(allContainers.map(({ Id }) => Id)) })
+        ? setFilters({
+            stdout: true,
+            stderr: true,
+            allowedContainers: new Set(allContainers.map(({ Id }) => Id)),
+          })
         : setFilters({ ...filters });
       const updatedContainerLabelColor = allContainers.reduce(
         (prevContainerLabelColor, container, index) => ({

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -202,29 +202,3 @@ export default function Logs() {
     </>
   );
 }
-
-/*
-if (
-  allContainers.length > containers.length &&
-  (filters.allowedContainers.size < containers.length || !filters.stderr || !filters.stdout)
-) {
-  setFilters({
-    ...filters,
-    allowedContainers: filters.allowedContainers.add(allContainers[0].Id),
-  });
-} // If no new containers but filters are applied
-else if (
-  allContainers.length === containers.length &&
-  (filters.allowedContainers.size < containers.length || !filters.stdout || !filters.stderr)
-) {
-  setFilters({ ...filters });
-} // On initial render as well as if no new containers as well as no filters applied
-else {
-  setFilters({
-    stdout: true,
-    stderr: true,
-    allowedContainers: new Set(allContainers.map(({ Id }) => Id)),
-  });
-}
-
-*/

--- a/ui/src/pages/Logs/Logs.tsx
+++ b/ui/src/pages/Logs/Logs.tsx
@@ -93,45 +93,25 @@ export default function Logs() {
     try {
       const allContainers = await fetchAllContainers(ddClient);
       const allContainerLogs = await fetchAllContainerLogs(ddClient, allContainers);
-      // Added new container and filters are applied
-      if (
-        allContainers.length > containers.length &&
-        (filters.allowedContainers.size < containers.length || !filters.stderr || !filters.stdout)
-      ) {
-        setFilters({
-          ...filters,
-          allowedContainers: filters.allowedContainers.add(allContainers[0].Id),
-        });
-      } // If no new containers but filters are applied
-      else if (
-        allContainers.length === containers.length &&
-        (filters.allowedContainers.size < containers.length || !filters.stdout || !filters.stderr)
-      ) {
-        setFilters({ ...filters });
-      } // On initial render as well as if no new containers as well as no filters applied
-      else {
-        setFilters({
-          stdout: true,
-          stderr: true,
-          allowedContainers: new Set(allContainers.map(({ Id }) => Id)),
-        });
-      }
+
+      const newAllowedContainers = new Set(allContainers.map(({ Id }) => Id));
+      containers
+        .filter((container) => !filters.allowedContainers.has(container.Id))
+        .forEach(({ Id }) => newAllowedContainers.delete(Id));
+
+      setFilters({ ...filters, allowedContainers: newAllowedContainers });
+
       setContainers(allContainers);
       setLogs(allContainerLogs);
-      const updatedContainerLabelColor = allContainers.reduce(
-        (prevContainerLabelColor, container, index) => ({
-          ...prevContainerLabelColor,
-          [container.Id]: colorArray[index % colorArray.length],
-        }),
-        {}
+      const updatedContainerLabelColor = Object.fromEntries(
+        allContainers.map((container, index) => [
+          container.Id,
+          colorArray[index % colorArray.length],
+        ])
       );
       setContainerLabelColor(updatedContainerLabelColor);
-      const updatedContainerIconColor = allContainers.reduce(
-        (prevContainerIconColor, container) => ({
-          ...prevContainerIconColor,
-          [container.Id]: container.State,
-        }),
-        {}
+      const updatedContainerIconColor = Object.fromEntries(
+        allContainers.map((container) => [container.Id, container.State])
       );
       setContainerIconColor(updatedContainerIconColor);
       setElapsedTimeInMinutes(0);
@@ -222,3 +202,29 @@ export default function Logs() {
     </>
   );
 }
+
+/*
+if (
+  allContainers.length > containers.length &&
+  (filters.allowedContainers.size < containers.length || !filters.stderr || !filters.stdout)
+) {
+  setFilters({
+    ...filters,
+    allowedContainers: filters.allowedContainers.add(allContainers[0].Id),
+  });
+} // If no new containers but filters are applied
+else if (
+  allContainers.length === containers.length &&
+  (filters.allowedContainers.size < containers.length || !filters.stdout || !filters.stderr)
+) {
+  setFilters({ ...filters });
+} // On initial render as well as if no new containers as well as no filters applied
+else {
+  setFilters({
+    stdout: true,
+    stderr: true,
+    allowedContainers: new Set(allContainers.map(({ Id }) => Id)),
+  });
+}
+
+*/


### PR DESCRIPTION
### Overview:

- Initial load of page renders all logs with all filters checked off
- Filters persist when user refreshes the page
- If a user adds a new container and then refreshes the page, the new container will show up by default, and filters persist


**Last Refresh 9 minutes ago**
![Screenshot 2023-07-04 at 4 07 50 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/035cbea7-bea1-40b2-9dc9-409566b6c9c3)

**User Refreshes page and filters persist**
![Screenshot 2023-07-04 at 4 08 05 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/370877b8-350b-4e05-8d0a-ec3aed88e3c7)

**Before adding new container**
![Screenshot 2023-07-05 at 1 06 16 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/4be2a141-e86e-401c-b42e-d812e0bfc23c)

**After adding new container and refreshing page**
![Screenshot 2023-07-05 at 1 09 34 PM](https://github.com/oslabs-beta/DockerPulse/assets/110566167/f2d8be29-50c0-4d3b-8b9f-49302b9038e2)


