### PR TITLE
Fix latency problem on Logs page

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -27,7 +27,7 @@ metricsServer.listen(METRICS_PORT, () => {
 
 (async () => {
   try {
-    // Wait 15 seconds to give the Grafana container extra time to spin up and be ready to respond
+    // Wait 10 seconds to give the Grafana container extra time to spin up and be ready to respond
     // to requests. This implementation can be improved later.
     console.log('⏳ Waiting ... ');
     await new Promise((r) => setTimeout(r, 1000 * 10));

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,7 +17,8 @@
         "lodash.debounce": "^4.0.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.12.1"
+        "react-router-dom": "^6.12.1",
+        "react-virtuoso": "^4.3.11"
       },
       "devDependencies": {
         "@docker/extension-api-client-types": "0.3.4",
@@ -14716,6 +14717,18 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-virtuoso": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.3.11.tgz",
+      "integrity": "sha512-0YrCvQ5GsIKRcN34GxrzhSJGuMNI+hGxWci5cTVuPQ8QWTEsrKfCyqm7YNBMmV3pu7onG1YVUBo86CyCXdejXg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18",
+        "react-dom": ">=16 || >=17 || >= 18"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -27144,6 +27157,12 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
+    },
+    "react-virtuoso": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.3.11.tgz",
+      "integrity": "sha512-0YrCvQ5GsIKRcN34GxrzhSJGuMNI+hGxWci5cTVuPQ8QWTEsrKfCyqm7YNBMmV3pu7onG1YVUBo86CyCXdejXg==",
+      "requires": {}
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,8 @@
     "lodash.debounce": "^4.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.12.1"
+    "react-router-dom": "^6.12.1",
+    "react-virtuoso": "^4.3.11"
   },
   "scripts": {
     "dev": "vite",

--- a/ui/src/components/LogsRow/LogsRow.tsx
+++ b/ui/src/components/LogsRow/LogsRow.tsx
@@ -3,7 +3,7 @@ import { KeyboardArrowUp, KeyboardArrowDown, ErrorRounded } from '@mui/icons-mat
 import { Box, Typography, IconButton, TableCell, TableRow, Collapse } from '@mui/material';
 import ContainerIcon from '../ContainerIcon/ContainerIcon';
 import { DockerLog, DDClient } from '../../types';
-import { HEADERS, theme } from '../../pages/Logs/Logs';
+import { theme } from '../../pages/Logs/Logs';
 
 const logsDisplayStyle = {
   whiteSpace: 'nowrap',
@@ -12,17 +12,21 @@ const logsDisplayStyle = {
   fontFamily: 'monospace',
 };
 
+type LogsRowProps = {
+  logInfo: DockerLog;
+  containerLabelColor: Record<string, string>;
+  containerIconColor: Record<string, string>;
+  ddClient: DDClient;
+  headers: string[];
+};
+
 export default function LogsRow({
   logInfo: logInfo,
   containerLabelColor,
   containerIconColor,
   ddClient,
-}: {
-  logInfo: DockerLog;
-  containerLabelColor: Record<string, string>;
-  containerIconColor: Record<string, string>;
-  ddClient: DDClient;
-}) {
+  headers,
+}: LogsRowProps) {
   const { containerId, containerName, time, stream, log } = logInfo;
   const [open, setOpen] = useState<boolean>(false);
   const [CPU, setCPU] = useState('');
@@ -76,9 +80,9 @@ export default function LogsRow({
       return (
         <Box sx={{ display: 'flex', alignContent: 'flex-end', fontSize: '11px', mt: 1 }}>
           <Typography>Closest metrics datapoint {time.slice(0, 19)} ·</Typography>
-          <Typography sx={{color: 'green'}}>CPU %:</Typography>
+          <Typography sx={{ color: 'green' }}>CPU %:</Typography>
           <Typography>{CPU} ·</Typography>
-          <Typography sx={{color: 'green'}}>MEM %:</Typography>
+          <Typography sx={{ color: 'green' }}>MEM %:</Typography>
           <Typography>{MEM}</Typography>
         </Box>
       );
@@ -152,7 +156,7 @@ export default function LogsRow({
       </TableRow>
       <TableRow>
         <TableCell sx={{ p: 0 }} />
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={HEADERS.length - 1}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={headers.length - 1}>
           <Collapse in={open} addEndListener={fetchMetrics} timeout="auto" unmountOnExit>
             {buildMetricsRow()}
             <Box

--- a/ui/src/components/LogsTable/LogsTable.tsx
+++ b/ui/src/components/LogsTable/LogsTable.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import { TableVirtuoso, TableComponents } from 'react-virtuoso';
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Typography,
+  Paper,
+  Box,
+} from '@mui/material';
+import LogsRow from '../LogsRow/LogsRow';
+import { LogFilters, DockerLog, DDClient } from '../../types';
+
+const HEADERS = ['', 'Timestamp', 'Container', 'Message'];
+
+type LogsTableProps = {
+  searchText: string;
+  filters: LogFilters;
+  logs: DockerLog[];
+  validFromTimestamp: string;
+  validUntilTimestamp: string;
+  containerLabelColor: Record<string, string>;
+  containerIconColor: Record<string, string>;
+  ddClient: DDClient;
+};
+
+export function LogsTable({
+  searchText,
+  filters,
+  logs,
+  validFromTimestamp,
+  validUntilTimestamp,
+  containerLabelColor,
+  containerIconColor,
+  ddClient,
+}: LogsTableProps) {
+  const [filteredLogs, setFilteredLogs] = useState<DockerLog[]>([]);
+
+  const filterAllLogs = async () => {
+    const upperCaseSearchText = searchText.toUpperCase();
+
+    const logEscapesFilter = ({ containerName, containerId, time, stream, log }: DockerLog) => {
+      if (!filters.stdout && stream === 'stdout') return false;
+      if (!filters.stderr && stream === 'stderr') return false;
+      if (!filters.allowedContainers.has(containerId)) return false;
+      const convertTime = time.slice(0, time.indexOf('.') + 4);
+      const numTime = Date.parse(convertTime);
+      const numFromTime = Date.parse(validFromTimestamp);
+      const numUntilTime = Date.parse(validUntilTimestamp);
+      if (!log.toUpperCase().includes(upperCaseSearchText)) return false;
+      if (numTime > numUntilTime || numTime < numFromTime) return false;
+      return true;
+    };
+
+    const filteredLogs = [];
+    for (const log of logs) {
+      if (logEscapesFilter(log)) filteredLogs.push(log);
+    }
+
+    return filteredLogs;
+  };
+
+  useEffect(() => {
+    (async () => {
+      const newFilteredLogs = await filterAllLogs();
+      setFilteredLogs(newFilteredLogs);
+    })();
+  }, [searchText, filters, logs, validFromTimestamp, validUntilTimestamp]);
+
+  const VirtuosoTableComponents: TableComponents<DockerLog> = {
+    Scroller: React.forwardRef<HTMLDivElement>((props, ref) => (
+      <TableContainer component={Paper} {...props} ref={ref} />
+    )),
+    Table: (props) => <Table {...props} />,
+    TableHead: TableHead,
+    TableRow: (props) => <div {...props} />, // Normally <TableRow />, workaround
+    TableBody: React.forwardRef<HTMLTableSectionElement>((props, ref) => (
+      <TableBody {...props} ref={ref} />
+    )),
+  };
+
+  // // Commented out because headers do not stay aligned with the table cells
+  // // due to the issue described below.
+  // const fixedHeaderContent = () => {
+  //   return (
+  //     <TableRow>
+  //       {HEADERS.map((header) => (
+  //         <TableCell>
+  //           <Typography sx={{ whiteSpace: 'nowrap', fontWeight: 'bold' }}>{header}</Typography>
+  //         </TableCell>
+  //       ))}
+  //     </TableRow>
+  //   );
+  // };
+
+  const rowContent = (_index: number, logInfo: DockerLog) => {
+    // This function is passed to the `itemContent` prop in <TableVirtuoso />
+    // Normally, this function should return table cell components, such as:
+    // return (<><TableCell /><TableCell /><TableCell /></>);
+    // However, to use our custom LogsRow component, we return it here instead.
+    return (
+      <LogsRow
+        logInfo={logInfo}
+        containerLabelColor={containerLabelColor}
+        containerIconColor={containerIconColor}
+        ddClient={ddClient}
+        headers={HEADERS}
+      />
+    );
+  };
+
+  return (
+    <Box sx={{ paddingTop: 2, flexGrow: 1 }}>
+      <TableVirtuoso
+        style={{
+          background: 'none',
+          border: 'none',
+        }}
+        data={filteredLogs}
+        components={VirtuosoTableComponents}
+        itemContent={rowContent}
+      />
+    </Box>
+  );
+}

--- a/ui/src/components/LogsTable/LogsTable.tsx
+++ b/ui/src/components/LogsTable/LogsTable.tsx
@@ -1,16 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { TableVirtuoso, TableComponents } from 'react-virtuoso';
-import {
-  TableContainer,
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableCell,
-  Typography,
-  Paper,
-  Box,
-} from '@mui/material';
+import { TableContainer, Table, TableHead, TableBody, Paper, Box } from '@mui/material';
 import LogsRow from '../LogsRow/LogsRow';
 import { LogFilters, DockerLog, DDClient } from '../../types';
 
@@ -81,20 +71,6 @@ export function LogsTable({
       <TableBody {...props} ref={ref} />
     )),
   };
-
-  // // Commented out because headers do not stay aligned with the table cells
-  // // due to the issue described below.
-  // const fixedHeaderContent = () => {
-  //   return (
-  //     <TableRow>
-  //       {HEADERS.map((header) => (
-  //         <TableCell>
-  //           <Typography sx={{ whiteSpace: 'nowrap', fontWeight: 'bold' }}>{header}</Typography>
-  //         </TableCell>
-  //       ))}
-  //     </TableRow>
-  //   );
-  // };
 
   const rowContent = (_index: number, logInfo: DockerLog) => {
     // This function is passed to the `itemContent` prop in <TableVirtuoso />


### PR DESCRIPTION
## Overview

Previously, the logs page would have performance issues if there were many logs to render. I initially thought this is an issue of the filter algorithm taking time, but some testing shows that it is simply due to the amount of components that were being rendered.

To fix this issue I added `react-virtuoso` to the project and used a VirtuosoTable for the logs, which is meant for displaying large data sets like ours with virtualized rendering to significantly improve performance (and NOT render so many components at a time).

https://virtuoso.dev/

### Important Notes

This PR does remove the headers from the table due to an issue using the VirtuosoTable API that is making it difficult for us to use our custom LogsRow component and still have the table headers align with the table cells. More comments about this issue in the code.

*VIEW DEMO with thousands of logs* https://imgur.com/a/Dg4Yy4c


