### PR TITLE
Display number of filtered and total logs

### DIFF
--- a/ui/src/components/LogsTable/LogsTable.tsx
+++ b/ui/src/components/LogsTable/LogsTable.tsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { TableVirtuoso, TableComponents } from 'react-virtuoso';
-import { TableContainer, Table, TableHead, TableBody, Paper, Box } from '@mui/material';
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  Paper,
+  Typography,
+  Stack,
+  Divider,
+} from '@mui/material';
 import LogsRow from '../LogsRow/LogsRow';
 import { LogFilters, DockerLog, DDClient } from '../../types';
 
@@ -89,7 +98,7 @@ export function LogsTable({
   };
 
   return (
-    <Box sx={{ paddingTop: 2, flexGrow: 1 }}>
+    <Stack sx={{ paddingTop: 2, flexGrow: 1 }}>
       <TableVirtuoso
         style={{
           background: 'none',
@@ -99,6 +108,10 @@ export function LogsTable({
         components={VirtuosoTableComponents}
         itemContent={rowContent}
       />
-    </Box>
+      <Stack spacing={1}>
+        <Divider sx={{ m: 0 }} />
+        <Typography variant="caption">{`Showing ${filteredLogs.length} of ${logs.length} logs`}</Typography>
+      </Stack>
+    </Stack>
   );
 }


### PR DESCRIPTION
Underneath the LogsTable, added text which displays the number of *filtered* and *total* logs. This gives the user better context and also serves to indicate that the user has filters applied.

![Screenshot 2023-07-05 at 11 23 09 AM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/e5b4d15f-f9dd-44f5-a2c8-982d9799c8ef)

![Screenshot 2023-07-05 at 11 23 17 AM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/e1aab4c7-f007-4164-aa6b-81986464d700)
