### PR TITLE
Add Network I/O and PIDs to exposed metrics from Docker containers

### DIFF
--- a/backend/src/actions/docker/calculateDockerStats.ts
+++ b/backend/src/actions/docker/calculateDockerStats.ts
@@ -6,7 +6,7 @@
  */
 
 export default function calculateDockerStats(stats: any) {
-  const { memory_stats, cpu_stats, precpu_stats } = stats;
+  const { memory_stats, cpu_stats, precpu_stats, networks, pids_stats } = stats;
 
   // Calculate memory usage as a percent
   const used_memory = memory_stats.usage - (memory_stats.stats?.cache || 0);
@@ -19,5 +19,16 @@ export default function calculateDockerStats(stats: any) {
   const number_cpus = cpu_stats.online_cpus;
   const cpu_usage_percent = (cpu_delta / system_cpu_delta) * number_cpus * 100.0;
 
-  return { cpu_usage_percent, memory_usage_percent };
+  // Calculate network I/O
+  const allNetworks = Object.values(networks || {}) as {
+    rx_bytes?: number;
+    tx_bytes?: number;
+  }[];
+  const network_in_bytes = allNetworks.reduce((sum, network) => sum + (network.rx_bytes || 0), 0);
+  const network_out_bytes = allNetworks.reduce((sum, network) => sum + (network.tx_bytes || 0), 0);
+
+  // Calculate PIDs
+  const pids = pids_stats.current || 0;
+
+  return { cpu_usage_percent, memory_usage_percent, network_in_bytes, network_out_bytes, pids };
 }

--- a/backend/src/actions/docker/startContainerMetricsStream.ts
+++ b/backend/src/actions/docker/startContainerMetricsStream.ts
@@ -1,6 +1,12 @@
 import axios from 'axios';
 import { DOCKER_DAEMON_SOCKET_PATH } from '../../constants';
-import { cpuGauge, memoryGauge } from '../../promClient';
+import {
+  cpuGauge,
+  memoryGauge,
+  networkInGauge,
+  networkOutGauge,
+  pidsGauge,
+} from '../../promClient';
 import calculateDockerStats from './calculateDockerStats';
 
 // This is a streaming connection that will close when the container is deleted.
@@ -15,12 +21,18 @@ export default async function startContainerMetricsStream(id: string) {
 
   stream.on('data', (data: Buffer) => {
     const stats = JSON.parse(data.toString());
+
     // Calculate the CPU % and MEM %
     // If the container is stopped, these values will be NaN
-    const { cpu_usage_percent, memory_usage_percent } = calculateDockerStats(stats);
+    const { cpu_usage_percent, memory_usage_percent, network_in_bytes, network_out_bytes, pids } =
+      calculateDockerStats(stats);
+
     // Set the metrics gauges of the prometheus client
     cpuGauge.labels({ id }).set(cpu_usage_percent);
     memoryGauge.labels({ id }).set(memory_usage_percent);
+    networkInGauge.labels({ id }).set(network_in_bytes);
+    networkOutGauge.labels({ id }).set(network_out_bytes);
+    pidsGauge.labels({ id }).set(pids);
   });
 
   stream.on('end', () => {

--- a/backend/src/promClient.ts
+++ b/backend/src/promClient.ts
@@ -13,7 +13,28 @@ export const memoryGauge = new prometheusClient.Gauge({
   labelNames: ['id'],
 });
 
+export const networkInGauge = new prometheusClient.Gauge({
+  name: 'network_in_bytes',
+  help: 'network_in_bytes',
+  labelNames: ['id'],
+});
+
+export const networkOutGauge = new prometheusClient.Gauge({
+  name: 'network_out_bytes',
+  help: 'network_out_bytes',
+  labelNames: ['id'],
+});
+
+export const pidsGauge = new prometheusClient.Gauge({
+  name: 'pids',
+  help: 'pids',
+  labelNames: ['id'],
+});
+
 // Create Prometheus register and register the gauges
 export const register = new prometheusClient.Registry();
 register.registerMetric(cpuGauge);
 register.registerMetric(memoryGauge);
+register.registerMetric(networkInGauge);
+register.registerMetric(networkOutGauge);
+register.registerMetric(pidsGauge);


### PR DESCRIPTION
## Overview

Add the following metrics to prometheus by calculating them and exposing them on port 3333:
- network in (rx)
- network out (tx)
- PIDs (the number of processes or threads the container has created)

Proof that they are being calculated correctly - compare directly against `docker stats` result in terminal:

![Screenshot 2023-07-05 at 7 09 21 PM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/16f33c44-1e07-4944-8e63-c0d201e890b9)
