### PR TITLE
Alerts trigger and show on front end

### DIFF
--- a/ui/src/pages/Alerts/Alerts.tsx
+++ b/ui/src/pages/Alerts/Alerts.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { createDockerDesktopClient } from '@docker/extension-api-client';
 import { Box, Stack, Button, Typography, Card, IconButton, Snackbar, Alert } from '@mui/material';
-import { Edit, Delete, ConstructionOutlined } from '@mui/icons-material';
+import { Edit, Delete } from '@mui/icons-material';
 import AlertDialog from '../../components/AlertDialog/AlertDialog';
 import { UserAlert, PopupAlertType, ResponseErr, DialogSettings } from '../../types';
 
@@ -49,17 +49,26 @@ export default function Alerts() {
     });
   };
 
-  // Fetch the user's saved alerts from the extension server
   useEffect(() => {
-    (async () => {
-      try {
-        const response = (await ddClient.extension.vm?.service?.get('/api/alerts')) as UserAlert[];
-        return setUserAlerts(response);
-      } catch (err) {
-        triggerPopupAlertFromErr(err);
-      }
-    })();
+    // Refresh the alerts every 5 seconds
+    const intervalId = setInterval(() => {
+      refreshAlerts();
+    }, 5000);
+
+    refreshAlerts(); // Invoke on mount
+
+    return () => clearInterval(intervalId);
   }, []);
+
+  // Fetch the user's saved alerts from the extension server
+  const refreshAlerts = async () => {
+    try {
+      const response = (await ddClient.extension.vm?.service?.get('/api/alerts')) as UserAlert[];
+      return setUserAlerts(response);
+    } catch (err) {
+      triggerPopupAlertFromErr(err);
+    }
+  };
 
   const handleCreateUserAlert = async () => {
     try {
@@ -231,11 +240,13 @@ function AlertCard({
           </Stack>
           <Stack sx={{ pr: 2, py: 1 }}>
             <Typography variant="caption">Threshold Last Exceeded</Typography>
-            <Typography>{lastExceeded}</Typography>
+            <Typography>{lastExceeded ? timestampToISOString(lastExceeded) : '-'}</Typography>
           </Stack>
           <Stack sx={{ pr: 2, py: 1 }}>
             <Typography variant="caption">Last Notification Sent</Typography>
-            <Typography>{lastNotification}</Typography>
+            <Typography>
+              {lastNotification ? timestampToISOString(lastNotification) : '-'}
+            </Typography>
           </Stack>
           <Stack sx={{ pr: 2, py: 1 }}>
             <Typography variant="caption">Notification Email</Typography>
@@ -243,10 +254,15 @@ function AlertCard({
           </Stack>
           <Stack sx={{ pr: 2, py: 1 }}>
             <Typography variant="caption">Alert Created</Typography>
-            <Typography>{created}</Typography>
+            <Typography>{created ? timestampToISOString(created) : '-'}</Typography>
           </Stack>
         </Box>
       </Stack>
     </Card>
   );
+}
+
+function timestampToISOString(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toISOString();
 }

--- a/ui/src/pages/Alerts/Alerts.tsx
+++ b/ui/src/pages/Alerts/Alerts.tsx
@@ -1,6 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { createDockerDesktopClient } from '@docker/extension-api-client';
-import { Box, Stack, Button, Typography, Card, IconButton, Snackbar, Alert } from '@mui/material';
+import {
+  Box,
+  Stack,
+  Button,
+  Typography,
+  Card,
+  IconButton,
+  Snackbar,
+  Alert,
+  Chip,
+} from '@mui/material';
 import { Edit, Delete } from '@mui/icons-material';
 import AlertDialog from '../../components/AlertDialog/AlertDialog';
 import { UserAlert, PopupAlertType, ResponseErr, DialogSettings } from '../../types';
@@ -202,7 +212,10 @@ function AlertCard({
             alignItems: 'center',
           }}
         >
-          <Typography variant="h3">{name}</Typography>
+          <Typography variant="h3" sx={{ mr: 2 }}>
+            {name}
+          </Typography>
+          {lastExceeded && <Chip label="threshold exceeded" color="error" />}
           <IconButton
             sx={{ ml: 'auto' }}
             onClick={() => {
@@ -250,7 +263,7 @@ function AlertCard({
           </Stack>
           <Stack sx={{ pr: 2, py: 1 }}>
             <Typography variant="caption">Notification Email</Typography>
-            <Typography>{email}</Typography>
+            <Typography>{email || '-'}</Typography>
           </Stack>
           <Stack sx={{ pr: 2, py: 1 }}>
             <Typography variant="caption">Alert Created</Typography>


### PR DESCRIPTION
Inside the stream of each container, when a new second of data is calculated, we check and see if an alert was triggered.

On the client, the Stats page will refresh the alerts every 5 seconds. The **Threshold Last Exceeded** field updates!

This was tested using an app which can spike CPU and MEM (via optical character recognition processes).

![Screenshot 2023-07-05 at 8 39 01 PM](https://github.com/oslabs-beta/DockerPulse/assets/121207468/82ac5aba-8d49-4209-84b5-a52d7448c5a7)

