### PR TITLE
Sort logs after fetch and display higher frequency data

### DIFF
--- a/backend/src/actions/grafana/createGrafanaPanelObject.ts
+++ b/backend/src/actions/grafana/createGrafanaPanelObject.ts
@@ -112,7 +112,7 @@ export default function createGrafanaPanelObject(
     targets: [],
     title: '', // No title on panel to conserve vertical space
     type: 'timeseries',
-    interval: '10s',
+    interval: '2s',
   };
 
   // Switch case to handle name of panel.

--- a/imageConfigs/prometheus/prometheus.yml
+++ b/imageConfigs/prometheus/prometheus.yml
@@ -3,6 +3,6 @@
 
 scrape_configs:
   - job_name: docker_container_metrics
-    scrape_interval: 5s
+    scrape_interval: 2s
     static_configs:
       - targets: ['host.docker.internal:3333']

--- a/ui/src/actions/fetchAllContainerLogs.ts
+++ b/ui/src/actions/fetchAllContainerLogs.ts
@@ -48,6 +48,9 @@ export default async function fetchAllContainerLogs(
       }
     }
 
+    // Sort by logs by timestamp
+    allLogs.sort((a, b) => Date.parse(a.time) - Date.parse(b.time));
+
     return allLogs;
   } catch (err) {
     console.error('Error retrieving container logs: ', err);

--- a/ui/src/components/StatsGraph/StatsGraph.tsx
+++ b/ui/src/components/StatsGraph/StatsGraph.tsx
@@ -35,7 +35,7 @@ export default function StatsGraph({ containerName, containerID }: StatsGraphPro
         </Select>
       </FormControl>
       <iframe
-        src={`http://localhost:2999/d-solo/${shortContainerID}/${containerName}?orgId=1&refresh=15s&panelId=1&from=now-${timeFrame}&to=now`}
+        src={`http://localhost:2999/d-solo/${shortContainerID}/${containerName}?orgId=1&refresh=5s&panelId=1&from=now-${timeFrame}&to=now`}
         width="100%"
         height="300px"
         style={{ border: 0 }}


### PR DESCRIPTION
### Logs 

Logs are fetched one container at a time, then all logs are added to an array.

This change then sorts ALL logs from ALL containers by the timestamp. Now, logs display chronologically isntead of being grouped by container:

<img width="1131" alt="Screenshot 2023-07-05 at 10 23 28 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/121207468/71bbfe89-4381-4fc8-bf6b-17b657ee0c62">

### Higher frequency data

- prometheus scrape interval decreased from 5s to 2s
- grafana panel interval decreased from 10s to 2s
- grafana embedded panel (iframe) refresh decreased from 15s to 5s

The result of theses changes are a higher frequency of data points, bringing a higher resolution to our metrics! Smaller duration spikes of resource usage are more likely to be captured by our time-series.

BEFORE CHANGE:
<img width="1131" alt="Screenshot 2023-07-05 at 10 16 05 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/121207468/20d1245d-2d66-402b-9605-e2cfe525b5f2">

AFTER CHANGE:
<img width="1131" alt="Screenshot 2023-07-05 at 10 23 46 PM" src="https://github.com/oslabs-beta/DockerPulse/assets/121207468/908f4f0a-60e3-4522-907a-c3f9f4a4b8af">



