### PR TITLE
Bug fix: alerts now only trigger on the correct container

### DIFF
--- a/backend/src/actions/docker/startContainerMetricsStream.ts
+++ b/backend/src/actions/docker/startContainerMetricsStream.ts
@@ -37,7 +37,11 @@ export default async function startContainerMetricsStream(id: string) {
 
     // Check if any of the user alert thresholds have been exceeded
     userAlerts.forEach((userAlert) => {
-      const { targetMetric, threshold } = userAlert;
+      const { targetMetric, threshold, containerId } = userAlert;
+
+      // If not for this container, return early
+      if (containerId !== id) return;
+
       switch (targetMetric) {
         case 'CPU %':
           if (cpu_usage_percent >= threshold) {


### PR DESCRIPTION
Before this fix, a threshold being exceeded would trigger all alerts for that target metric.

This is because we weren't narrowing it by container. 

This PR fixes the bug.